### PR TITLE
Feature/cosmwasm 0.16

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,14 +10,14 @@ name = "fadroma"
 path = "lib.rs"
 
 [dependencies]
-cosmwasm-schema   = { optional = true, git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-std      = { optional = true, git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-storage  = { optional = true, git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
+cosmwasm-schema   = { optional = true, git = "https://github.com/enigmampc/SecretNetwork", branch = "stargate-cosmwasm-v0.16" }
+cosmwasm-std      = { optional = true, git = "https://github.com/enigmampc/SecretNetwork", branch = "stargate-cosmwasm-v0.16" }
+cosmwasm-storage  = { optional = true, git = "https://github.com/enigmampc/SecretNetwork", branch = "stargate-cosmwasm-v0.16" }
 primitive-types   = { optional = true, version = "0.9.1", default-features = false }
 rand_chacha       = { optional = true, version = "0.2.2", default-features = false }
 rand_core         = { optional = true, version = "0.5.1", default-features = false }
-schemars          = { optional = true, version = "0.7" }
-secret-toolkit    = { optional = true, git = "https://github.com/enigmampc/secret-toolkit", branch = "debug-print" }
+schemars          = { optional = true, version = "0.8.1" }
+#secret-toolkit    = { optional = true, git = "https://github.com/enigmampc/secret-toolkit", branch = "debug-print" }
 #secret-toolkit   = { optional = true, git = "https://github.com/hackbg/secret-toolkit", rev = "9a33d7b" }
 serde             = { optional = true, version = "1.0.103", default-features = false, features = ["derive"] }
 sha2              = { optional = true, version = "0.9.1", default-features = false }
@@ -43,15 +43,15 @@ derive          = ["derive-contract"]
 
 scrt-all        = [
                     "scrt", "scrt-addr", "scrt-admin", "scrt-contract", "scrt-icc", "scrt-vk",
-                    "scrt-migrate", "scrt-snip20-api", "scrt-storage", "scrt-utils"
+                    "scrt-migrate", "scrt-storage", "scrt-utils"
                   ]
-scrt            = ["cosmwasm-std", "cosmwasm-storage", "cosmwasm-schema", "snafu", "schemars", "secret-toolkit"]
+scrt            = ["cosmwasm-std", "cosmwasm-storage", "cosmwasm-schema", "snafu", "schemars"]
 scrt-addr       = ["scrt"]
 scrt-admin      = ["derive", "scrt-storage", "require-admin"]
 scrt-contract   = ["scrt", "serde"]
 scrt-icc        = ["scrt", "scrt-addr", "serde"]
 scrt-migrate    = ["scrt-icc", "scrt-admin"]
-scrt-snip20-api = ["scrt"]
+#scrt-snip20-api = ["scrt"]
 scrt-storage    = ["scrt", "serde"]
 scrt-utils      = ["scrt", "rand_chacha", "rand_core", "sha2", "subtle", "primitive-types"]
 scrt-vk         = ["derive", "scrt-storage", "scrt-utils"]

--- a/lib/composable-admin/admin.rs
+++ b/lib/composable-admin/admin.rs
@@ -26,8 +26,10 @@ pub trait Admin {
     }
 
     #[handle]
-    fn change_admin(address: Addr) -> StdResult<Response> {
+    fn change_admin(address: String) -> StdResult<Response> {
         assert_admin(deps.as_ref(), &info)?;
+
+        let address = deps.api.addr_validate(address.as_str())?;
         save_admin(deps, &address)?;
     
         Ok(Response::default())
@@ -83,7 +85,7 @@ mod tests {
         save_admin(deps.as_mut(), &admin).unwrap();
 
         let msg = HandleMsg::ChangeAdmin { 
-            address: Addr::unchecked("will fail")
+            address: String::from("will fail")
         };
 
         let result = handle(
@@ -104,7 +106,7 @@ mod tests {
         let new_admin = Addr::unchecked("new_admin");
 
         let msg = HandleMsg::ChangeAdmin { 
-            address: new_admin.clone()
+            address: new_admin.to_string()
         };
 
         handle(

--- a/lib/derive-contract/Cargo.toml
+++ b/lib/derive-contract/Cargo.toml
@@ -13,8 +13,6 @@ syn = { version = "1.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 
 [dev-dependencies]
-cosmwasm-std     = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print", features = ["debug-print"] }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
+fadroma = { path = "../", features = ["scrt"] }
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 serde_json = "1.0.66"
-schemars = "0.7"

--- a/lib/derive-contract/src/lib.rs
+++ b/lib/derive-contract/src/lib.rs
@@ -32,7 +32,6 @@ pub fn contract_impl(args: proc_macro::TokenStream, trait_: proc_macro::TokenStr
 pub fn init(_args: proc_macro::TokenStream, func: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let mut ast = parse_macro_input!(func as TraitItemMethod);
 
-    add_deps_generics(&mut ast);
     add_fn_args(&mut ast, true);
 
     let result = quote! {
@@ -46,7 +45,6 @@ pub fn init(_args: proc_macro::TokenStream, func: proc_macro::TokenStream) -> pr
 pub fn handle(_args: proc_macro::TokenStream, func: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let mut ast = parse_macro_input!(func as TraitItemMethod);
 
-    add_deps_generics(&mut ast);
     add_fn_args(&mut ast, true);
 
     let result = quote! {
@@ -60,7 +58,6 @@ pub fn handle(_args: proc_macro::TokenStream, func: proc_macro::TokenStream) -> 
 pub fn query(_args: proc_macro::TokenStream, func: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let mut ast = parse_macro_input!(func as TraitItemMethod);
 
-    add_deps_generics(&mut ast);
     add_fn_args(&mut ast, false);
 
     let result = quote! {
@@ -110,19 +107,15 @@ fn generate_contract(
     proc_macro::TokenStream::from(result)
 }
 
-fn add_deps_generics(func: &mut TraitItemMethod) {    
-    func.sig.generics.params.push(parse_quote!(S: cosmwasm_std::Storage));
-    func.sig.generics.params.push(parse_quote!(A: cosmwasm_std::Api));
-    func.sig.generics.params.push(parse_quote!(Q: cosmwasm_std::Querier));
-}
-
 fn add_fn_args(func: &mut TraitItemMethod, is_tx: bool) {
     func.sig.inputs.insert(0, parse_quote!(&self));
     
     if is_tx {
-        func.sig.inputs.push(parse_quote!(deps: &mut cosmwasm_std::Extern<S, A, Q>));
+        func.sig.inputs.push(parse_quote!(deps: cosmwasm_std::DepsMut));
         func.sig.inputs.push(parse_quote!(env: cosmwasm_std::Env));
+        func.sig.inputs.push(parse_quote!(info: cosmwasm_std::MessageInfo));
     } else {
-        func.sig.inputs.push(parse_quote!(deps: &cosmwasm_std::Extern<S, A, Q>));
+        func.sig.inputs.push(parse_quote!(deps: cosmwasm_std::Deps));
+        func.sig.inputs.push(parse_quote!(env: cosmwasm_std::Env));
     }
 }

--- a/lib/derive-contract/tests/entry.rs
+++ b/lib/derive-contract/tests/entry.rs
@@ -1,6 +1,7 @@
-use cosmwasm_std::{StdResult, HandleResponse, InitResponse, to_vec, from_slice};
+use fadroma::scrt::{StdResult, Response, to_vec, from_slice};
+use fadroma::cosmwasm_std;
 use derive_contract::*;
-use schemars;
+use fadroma::schemars;
 use serde;
 
 const KEY_STRING: &[u8] = b"string_data";
@@ -8,17 +9,17 @@ const KEY_STRING: &[u8] = b"string_data";
 #[contract(entry)]
 pub trait StringComponent {
     #[init]
-    fn new(string: String) -> StdResult<InitResponse> {
+    fn new(string: String) -> StdResult<Response> {
         deps.storage.set(KEY_STRING, &to_vec(&string)?);
 
-        Ok(InitResponse::default())
+        Ok(Response::default())
     }
 
     #[handle]
-    fn set_string(string: String) -> StdResult<HandleResponse> {
+    fn set_string(string: String) -> StdResult<Response> {
         deps.storage.set(KEY_STRING, &to_vec(&string)?);
 
-        Ok(HandleResponse::default())
+        Ok(Response::default())
     }
 
     #[query("string")]

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -21,8 +21,10 @@ mod composable_admin;
 #[cfg(feature="scrt-icc")]        pub use scrt_link::*;
 #[cfg(feature="scrt-migrate")]    pub mod scrt_migrate;
 #[cfg(feature="scrt-migrate")]    pub use scrt_migrate::*;
+/* secret-toolkit not updated to cosmwasm 0.16
 #[cfg(feature="scrt-snip20-api")] pub mod scrt_snip20_api;
 #[cfg(feature="scrt-snip20-api")] pub use scrt_snip20_api::*;
+*/
 #[cfg(feature="scrt-storage")]    pub mod scrt_storage;
 #[cfg(feature="scrt-storage")]    pub mod scrt_storage_traits;
 #[cfg(feature="scrt-storage")]    pub mod scrt_storage_traits2;

--- a/lib/scrt.rs
+++ b/lib/scrt.rs
@@ -1,8 +1,9 @@
 pub const BLOCK_SIZE: usize = 256;
+pub use cosmwasm_std;
 pub use cosmwasm_std::*;
 #[cfg(test)] pub use cosmwasm_std::testing::*;
 pub use cosmwasm_storage::*;
 pub use cosmwasm_schema::*;
 pub use snafu;
 pub use schemars;
-pub use secret_toolkit;
+//pub use secret_toolkit;

--- a/lib/scrt_addr.rs
+++ b/lib/scrt_addr.rs
@@ -3,7 +3,7 @@
 use crate::scrt::{Api, StdResult, Addr, CanonicalAddr, Binary};
 
 pub trait Humanize<T> {
-    fn humanize (&self, api: &dyn Api) -> StdResult<T>;
+    fn humanize (self, api: &dyn Api) -> StdResult<T>;
 }
 
 pub trait Canonize<T> {
@@ -11,11 +11,11 @@ pub trait Canonize<T> {
 }
 
 /// Attempting to canonicalize an empty address will fail. 
-/// This function skips calling `canonical_address` if the input is empty
+/// This function skips calling `addr_canonicalize` if the input is empty
 /// and returns `CanonicalAddr::default()` instead.
 pub fn canonize_maybe_empty(api: &dyn Api, addr: &Addr) -> StdResult<CanonicalAddr> {
     Ok(
-        if *addr == Addr::unchecked("") {
+        if addr.as_str() == "" {
             CanonicalAddr(Binary(Vec::new()))
         } else {
             api.addr_canonicalize(addr.as_str())?
@@ -24,7 +24,7 @@ pub fn canonize_maybe_empty(api: &dyn Api, addr: &Addr) -> StdResult<CanonicalAd
 }
 
 /// Attempting to humanize an empty address will fail. 
-/// This function skips calling `human_address` if the input is empty
+/// This function skips calling `addr_humanize` if the input is empty
 /// and returns `Addr::default()` instead.
 pub fn humanize_maybe_empty(api: &dyn Api, addr: &CanonicalAddr) -> StdResult<Addr> {
     Ok(
@@ -37,14 +37,14 @@ pub fn humanize_maybe_empty(api: &dyn Api, addr: &CanonicalAddr) -> StdResult<Ad
 }
 
 impl Humanize<Addr> for CanonicalAddr {
-    fn humanize (&self, api: &dyn Api) -> StdResult<Addr> {
-        humanize_maybe_empty(api, self)
+    fn humanize (self, api: &dyn Api) -> StdResult<Addr> {
+        humanize_maybe_empty(api, &self)
     }
 }
 
 impl<T: Humanize<U>, U> Humanize<Vec<U>> for Vec<T> {
-    fn humanize (&self, api: &dyn Api) -> StdResult<Vec<U>> {
-        self.iter().map(|x|x.humanize(api)).collect()
+    fn humanize (mut self, api: &dyn Api) -> StdResult<Vec<U>> {
+        self.drain(..).map(|x|x.humanize(api)).collect()
     }
 }
 

--- a/lib/scrt_callback.rs
+++ b/lib/scrt_callback.rs
@@ -20,7 +20,7 @@ impl Canonize<Callback<CanonicalAddr>> for Callback<Addr> {
     }
 }
 impl Humanize<Callback<Addr>> for Callback<CanonicalAddr> {
-    fn humanize (&self, api: &dyn Api) -> StdResult<Callback<Addr>> {
-        Ok(Callback { msg: self.msg.clone(), contract: self.contract.humanize(api)? })
+    fn humanize (self, api: &dyn Api) -> StdResult<Callback<Addr>> {
+        Ok(Callback { msg: self.msg, contract: self.contract.humanize(api)? })
     }
 }

--- a/lib/scrt_callback.rs
+++ b/lib/scrt_callback.rs
@@ -1,5 +1,5 @@
 use crate::{
-    scrt::{StdResult, HumanAddr, CanonicalAddr, Api, Binary},
+    scrt::{StdResult, Addr, CanonicalAddr, Api, Binary},
     scrt_link::ContractLink,
     scrt_addr::{Canonize, Humanize}
 };
@@ -14,13 +14,13 @@ pub struct Callback<A> {
     /// Info about the contract requesting the callback.
     pub contract: ContractLink<A>
 }
-impl Canonize<Callback<CanonicalAddr>> for Callback<HumanAddr> {
-    fn canonize (&self, api: &impl Api) -> StdResult<Callback<CanonicalAddr>> {
+impl Canonize<Callback<CanonicalAddr>> for Callback<Addr> {
+    fn canonize (&self, api: &dyn Api) -> StdResult<Callback<CanonicalAddr>> {
         Ok(Callback { msg: self.msg.clone(), contract: self.contract.canonize(api)? })
     }
 }
-impl Humanize<Callback<HumanAddr>> for Callback<CanonicalAddr> {
-    fn humanize (&self, api: &impl Api) -> StdResult<Callback<HumanAddr>> {
+impl Humanize<Callback<Addr>> for Callback<CanonicalAddr> {
+    fn humanize (&self, api: &dyn Api) -> StdResult<Callback<Addr>> {
         Ok(Callback { msg: self.msg.clone(), contract: self.contract.humanize(api)? })
     }
 }

--- a/lib/scrt_contract.rs
+++ b/lib/scrt_contract.rs
@@ -8,7 +8,7 @@
 #[macro_export] macro_rules! prelude {
     () => { use fadroma::scrt::cosmwasm_std::{
         ReadonlyStorage, Storage, Api, Querier, Extern, Env,
-        HumanAddr, CanonicalAddr, Coin, Uint128,
+        Addr, CanonicalAddr, Coin, Uint128,
         StdResult, StdError,
         InitResponse, HandleResponse, LogAttribute, Binary,
         CosmosMsg, BankMsg, WasmMsg, to_binary,

--- a/lib/scrt_contract_binding.rs
+++ b/lib/scrt_contract_binding.rs
@@ -66,14 +66,14 @@
 
         #[derive(Copy, Clone)] pub struct Api;
         impl cw::Api for Api {
-            fn canonical_address (&self, addr: &cw::HumanAddr) -> cw::StdResult<cw::CanonicalAddr> {
+            fn canonical_address (&self, addr: &cw::Addr) -> cw::StdResult<cw::CanonicalAddr> {
                 Ok(cw::CanonicalAddr(cw::Binary(Vec::from(addr.as_str()))))
             }
-            fn human_address (&self, addr: &cw::CanonicalAddr) -> cw::StdResult<cw::HumanAddr> {
+            fn human_address (&self, addr: &cw::CanonicalAddr) -> cw::StdResult<cw::Addr> {
                 let trimmed: Vec<u8> = addr.as_slice().iter().cloned()
                     .filter(|&x| x != 0).collect();
                 // decode UTF-8 bytes into string
-                Ok(cw::HumanAddr(String::from_utf8(trimmed)
+                Ok(cw::Addr(String::from_utf8(trimmed)
                     .map_err(cw::StdError::invalid_utf8)?))
             }
         }
@@ -110,11 +110,11 @@
                                 chain_id: "fadroma".into()
                             },
                             message: cw::MessageInfo {
-                                sender:     cw::HumanAddr::from(""),
+                                sender:     cw::Addr::from(""),
                                 sent_funds: vec![]
                             },
                             contract: cw::ContractInfo {
-                                address: cw::HumanAddr::from("")
+                                address: cw::Addr::from("")
                             },
                             contract_key: Some("".into()),
                             contract_code_hash: "".into()

--- a/lib/scrt_link.rs
+++ b/lib/scrt_link.rs
@@ -30,10 +30,10 @@ impl Canonize<ContractLink<CanonicalAddr>> for ContractLink<Addr> {
     }
 }
 impl Humanize<ContractLink<Addr>> for ContractLink<CanonicalAddr> {
-    fn humanize (&self, api: &dyn Api) -> StdResult<ContractLink<Addr>> {
+    fn humanize (self, api: &dyn Api) -> StdResult<ContractLink<Addr>> {
         Ok(ContractLink {
             address:   self.address.humanize(api)?,
-            code_hash: self.code_hash.clone()
+            code_hash: self.code_hash
         })
     }
 }

--- a/lib/scrt_link.rs
+++ b/lib/scrt_link.rs
@@ -1,4 +1,7 @@
-use crate::{scrt::*, scrt_addr::*};
+use crate::{
+    scrt::{StdResult, Addr, CanonicalAddr, Api},
+    scrt_addr::{Humanize, Canonize}
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -18,16 +21,16 @@ pub struct ContractLink<A> {
     pub address:   A,
     pub code_hash: CodeHash
 }
-impl Canonize<ContractLink<CanonicalAddr>> for ContractLink<HumanAddr> {
-    fn canonize (&self, api: &impl Api) -> StdResult<ContractLink<CanonicalAddr>> {
+impl Canonize<ContractLink<CanonicalAddr>> for ContractLink<Addr> {
+    fn canonize (&self, api: &dyn Api) -> StdResult<ContractLink<CanonicalAddr>> {
         Ok(ContractLink {
             address:   self.address.canonize(api)?,
             code_hash: self.code_hash.clone()
         })
     }
 }
-impl Humanize<ContractLink<HumanAddr>> for ContractLink<CanonicalAddr> {
-    fn humanize (&self, api: &impl Api) -> StdResult<ContractLink<HumanAddr>> {
+impl Humanize<ContractLink<Addr>> for ContractLink<CanonicalAddr> {
+    fn humanize (&self, api: &dyn Api) -> StdResult<ContractLink<Addr>> {
         Ok(ContractLink {
             address:   self.address.humanize(api)?,
             code_hash: self.code_hash.clone()

--- a/lib/scrt_migrate.rs
+++ b/lib/scrt_migrate.rs
@@ -96,11 +96,11 @@ impl<A> Default for ContractStatus<A> {
     } }
 }
 impl Humanize<ContractStatus<Addr>> for ContractStatus<CanonicalAddr> {
-    fn humanize (&self, api: &dyn Api) -> StdResult<ContractStatus<Addr>> {
+    fn humanize (self, api: &dyn Api) -> StdResult<ContractStatus<Addr>> {
         Ok(ContractStatus {
-            level: self.level.clone(),
-            reason: self.reason.clone(),
-            new_address: match &self.new_address {
+            level: self.level,
+            reason: self.reason,
+            new_address: match self.new_address {
                 Some(canon_addr) => Some(api.addr_humanize(&canon_addr)?),
                 None => None
             }

--- a/lib/scrt_snip20_api.rs
+++ b/lib/scrt_snip20_api.rs
@@ -1,6 +1,6 @@
 use crate::{
     scrt::{
-        BLOCK_SIZE, HumanAddr, StdResult,
+        BLOCK_SIZE, Addr, StdResult,
         CosmosMsg, Uint128, Binary, Querier
     },
     scrt_link::ContractLink,
@@ -9,14 +9,14 @@ use crate::{
 
 
 pub struct ISnip20 <'a> {
-    pub link:   &'a ContractLink<HumanAddr>,
+    pub link:   &'a ContractLink<Addr>,
     padding:    Option<String>,
     block_size: usize
 }
 
 impl<'a> ISnip20<'a> {
 
-    pub fn attach (link: &'a ContractLink<HumanAddr>) -> Self {
+    pub fn attach (link: &'a ContractLink<Addr>) -> Self {
         Self {
             link,
             padding:    None,
@@ -25,7 +25,7 @@ impl<'a> ISnip20<'a> {
     }
 
     pub fn mint (
-        &self, recipient: &HumanAddr, amount: Uint128
+        &self, recipient: &Addr, amount: Uint128
     ) -> StdResult<CosmosMsg> {
         snip20::mint_msg(
             recipient.clone(), amount,
@@ -35,7 +35,7 @@ impl<'a> ISnip20<'a> {
     }
 
     pub fn set_minters (
-        &self, minters: &Vec<HumanAddr>
+        &self, minters: &Vec<Addr>
     ) -> StdResult<CosmosMsg> {
         snip20::set_minters_msg(
             minters.clone(),
@@ -45,7 +45,7 @@ impl<'a> ISnip20<'a> {
     }
 
     pub fn send (
-        &self, recipient: &HumanAddr, amount: Uint128, msg: Option<Binary>
+        &self, recipient: &Addr, amount: Uint128, msg: Option<Binary>
     ) -> StdResult<CosmosMsg> {
         snip20::send_msg(
             recipient.clone(), amount, msg,
@@ -55,7 +55,7 @@ impl<'a> ISnip20<'a> {
     }
 
     pub fn send_from (
-        &self, owner: &HumanAddr, recipient: &HumanAddr,
+        &self, owner: &Addr, recipient: &Addr,
         amount: Uint128, msg: Option<Binary>
     ) -> StdResult<CosmosMsg> {
         snip20::send_from_msg(
@@ -66,7 +66,7 @@ impl<'a> ISnip20<'a> {
     }
 
     pub fn transfer (
-        &self, recipient: &HumanAddr, amount: Uint128
+        &self, recipient: &Addr, amount: Uint128
     ) -> StdResult<CosmosMsg> {
         snip20::transfer_msg(
             recipient.clone(), amount,
@@ -76,7 +76,7 @@ impl<'a> ISnip20<'a> {
     }
 
     pub fn transfer_from (
-        &self, owner: &HumanAddr, recipient: &HumanAddr, amount: Uint128
+        &self, owner: &Addr, recipient: &Addr, amount: Uint128
     ) -> StdResult<CosmosMsg> {
         snip20::transfer_from_msg(
             owner.clone(), recipient.clone(), amount,
@@ -110,7 +110,7 @@ pub struct ISnip20Querier <'q, Q: Querier> {
 
 impl <'q, Q: Querier> ISnip20Querier <'q, Q> {
 
-    pub fn balance (&self, address: &HumanAddr, vk: &str) -> StdResult<Uint128> {
+    pub fn balance (&self, address: &Addr, vk: &str) -> StdResult<Uint128> {
         Ok(snip20::balance_query(
             self.querier,
             address.clone(), vk.into(),

--- a/lib/scrt_storage.rs
+++ b/lib/scrt_storage.rs
@@ -1,11 +1,11 @@
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-pub use crate::scrt::{ReadonlyStorage, StdResult, Storage, from_slice, to_vec};
+pub use crate::scrt::{StdResult, Storage, from_slice, to_vec};
 
 /// Save something to the storage.
 #[inline]
-pub fn save <T: Serialize, S: Storage> (
-    storage: &mut S,
+pub fn save <T: Serialize> (
+    storage: &mut dyn Storage,
     key:     &[u8],
     value:   &T
 ) -> StdResult<()> {
@@ -15,8 +15,8 @@ pub fn save <T: Serialize, S: Storage> (
 
 /// Remove something from the storage.
 #[inline]
-pub fn remove <S: Storage> (
-    storage: &mut S,
+pub fn remove (
+    storage: &mut dyn Storage,
     key:     &[u8]
 ) {
     storage.remove(key);
@@ -24,8 +24,8 @@ pub fn remove <S: Storage> (
 
 /// Load something from the storage.
 #[inline]
-pub fn load <T: DeserializeOwned, S: ReadonlyStorage> (
-    storage: &S,
+pub fn load <T: DeserializeOwned> (
+    storage: &dyn Storage,
     key:     &[u8]
 ) -> StdResult<Option<T>> {
     match storage.get(key) {
@@ -36,8 +36,8 @@ pub fn load <T: DeserializeOwned, S: ReadonlyStorage> (
 
 /// Save something to the storage under a namespaced key.
 #[inline]
-pub fn ns_save <T: Serialize, S: Storage> (
-    storage:   &mut S,
+pub fn ns_save <T: Serialize> (
+    storage: &mut dyn Storage,
     namespace: &[u8],
     key:       &[u8],
     value:     &T
@@ -48,8 +48,8 @@ pub fn ns_save <T: Serialize, S: Storage> (
 
 /// Remove the value of a namespaced key from the storage.
 #[inline]
-pub fn ns_remove <S: Storage> (
-    storage:   &mut S,
+pub fn ns_remove(
+    storage: &mut dyn Storage,
     namespace: &[u8],
     key:       &[u8]
 ) {
@@ -59,8 +59,8 @@ pub fn ns_remove <S: Storage> (
 
 /// Load the value of a namespaced key.
 #[inline]
-pub fn ns_load <T: DeserializeOwned, S: ReadonlyStorage> (
-    storage:   &S,
+pub fn ns_load <T: DeserializeOwned> (
+    storage: &dyn Storage,
     namespace: &[u8],
     key:       &[u8]
 ) -> StdResult<Option<T>> {

--- a/lib/scrt_storage_traits.rs
+++ b/lib/scrt_storage_traits.rs
@@ -30,12 +30,12 @@ use serde::{de::DeserializeOwned, Serialize};
 ///     }
 /// }
 /// 
-/// fn init<S: Storage, A: Api, Q: Querier>(deps: &mut Extern<S, A, Q>) -> StdResult<()> {
+/// fn init(mut deps: DepsMut) -> StdResult<()> {
 ///     let config = Config { some_value: "foo".to_string() };
 /// 
-///     config.save(deps)?;
+///     config.save(deps.branch())?;
 /// 
-///     let maybe_config: Option<Config> = Config::load(&deps, b"some_key")?;
+///     let maybe_config: Option<Config> = Config::load(deps.as_ref(), b"some_key")?;
 /// 
 ///     Ok(())
 /// }
@@ -45,7 +45,7 @@ pub trait Storable: Serialize + DeserializeOwned {
     fn key(&self) -> StdResult<Vec<u8>>;
 
     /// Save Self in the storage
-    fn save<S: Storage, A: Api, Q: Querier>(&self, deps: &mut Extern<S, A, Q>) -> StdResult<()> {
+    fn save(&self, deps: DepsMut) -> StdResult<()> {
         let key = self.key()?;
         let key = key.as_slice();
 
@@ -53,7 +53,7 @@ pub trait Storable: Serialize + DeserializeOwned {
     }
 
     /// Remove Self from storage
-    fn remove<S: Storage, A: Api, Q: Querier>(self, deps: &mut Extern<S, A, Q>) -> StdResult<()> {
+    fn remove(self, deps: DepsMut) -> StdResult<()> {
         let key = self.key()?;
         let key = key.as_slice();
 
@@ -74,32 +74,27 @@ pub trait Storable: Serialize + DeserializeOwned {
     }
 
     /// Static: Load Self from the storage
-    fn load<S: Storage, A: Api, Q: Querier>(
-        deps: &Extern<S, A, Q>,
-        key: &[u8],
-    ) -> StdResult<Option<Self>> {
+    fn load(deps: Deps, key: &[u8]) -> StdResult<Option<Self>> {
         let key = Self::concat_key(key);
 
-        storage_load::<Self, S>(&deps.storage, key.as_slice())
+        storage_load::<Self>(deps.storage, key.as_slice())
     }
 
     /// Static: Save Self in the storage
-    fn static_save<S: Storage, A: Api, Q: Querier>(
-        deps: &mut Extern<S, A, Q>,
+    fn static_save(
+        deps: DepsMut,
         key: &[u8],
         item: &Self,
     ) -> StdResult<()> {
         let key = Self::concat_key(key);
-        storage_save::<Self, S>(&mut deps.storage, &key.as_slice(), item)
+        storage_save::<Self>(deps.storage, &key.as_slice(), item)
     }
 
     /// Static: Remove Self from storage
-    fn static_remove<S: Storage, A: Api, Q: Querier>(
-        deps: &mut Extern<S, A, Q>,
-        key: &[u8],
+    fn static_remove(deps: DepsMut, key: &[u8]
     ) -> StdResult<()> {
         let key = Self::concat_key(key);
-        storage_remove(&mut deps.storage, &key.as_slice());
+        storage_remove(deps.storage, &key.as_slice());
 
         Ok(())
     }

--- a/lib/scrt_storage_traits2.rs
+++ b/lib/scrt_storage_traits2.rs
@@ -2,7 +2,7 @@ pub use serde::{Serialize, de::DeserializeOwned};
 use crate::{scrt::*, scrt_storage::concat};
 
 /// Trait for actor that operates in a context with readonly access to the storage.
-pub trait Readonly <S: ReadonlyStorage> {
+pub trait Readonly <S: Storage> {
     /// Get the storage handle
     fn storage (&self) -> &S;
     /// Load a global

--- a/lib/scrt_uint256.rs
+++ b/lib/scrt_uint256.rs
@@ -258,7 +258,7 @@ impl TryInto<Uint128> for Uint256 {
     type Error = StdError;
 
     fn try_into(self) -> Result<Uint128, Self::Error> {
-        self.clamp_u128().map(|x| Uint128(x))
+        self.clamp_u128().map(|x| Uint128::from(x))
     }
 }
 

--- a/lib/scrt_vk.rs
+++ b/lib/scrt_vk.rs
@@ -15,13 +15,13 @@ pub fn create_hashed_password(s1: &str) -> [u8; VIEWING_KEY_SIZE] {
 }
 
 impl ViewingKey {
-    pub fn new(env: &Env, seed: &[u8], entropy: &[u8]) -> Self {
+    pub fn new(env: &Env, info: &MessageInfo, seed: &[u8], entropy: &[u8]) -> Self {
         // 16 here represents the lengths in bytes of the block height and time.
-        let entropy_len = 16 + env.message.sender.len() + entropy.len();
+        let entropy_len = 16 + info.sender.as_str().len() + entropy.len();
         let mut rng_entropy = Vec::with_capacity(entropy_len);
         rng_entropy.extend_from_slice(&env.block.height.to_be_bytes());
-        rng_entropy.extend_from_slice(&env.block.time.to_be_bytes());
-        rng_entropy.extend_from_slice(&env.message.sender.0.as_bytes());
+        rng_entropy.extend_from_slice(&env.block.time.seconds().to_be_bytes());
+        rng_entropy.extend_from_slice(&info.sender.as_bytes());
         rng_entropy.extend_from_slice(entropy);
 
         let mut rng = Prng::new(seed, &rng_entropy);

--- a/lib/scrt_vk_auth.rs
+++ b/lib/scrt_vk_auth.rs
@@ -1,5 +1,5 @@
 use crate::{
-    scrt::*,
+    scrt::{StdError, DepsMut, Deps, Response, to_binary},
     scrt_storage::*,
     scrt_vk::*,
     derive_contract::{contract, handle}
@@ -12,32 +12,28 @@ const VIEWING_KEYS: &[u8] = b"XXzo7ZXRJ2";
 #[contract]
 pub trait Auth {
     #[handle]
-    fn create_viewing_key(entropy: String, _padding: Option<String>) -> StdResult<HandleResponse> {
+    fn create_viewing_key(entropy: String, _padding: Option<String>) -> StdResult<Response> {
         let prng_seed = [ 
-            env.block.time.to_be_bytes(),
+            env.block.time.seconds().to_be_bytes(),
             env.block.height.to_be_bytes() 
         ].concat();
 
-        let key = ViewingKey::new(&env, &prng_seed, &(entropy).as_ref());
-        let address = deps.api.canonical_address(&env.message.sender)?;
+        let key = ViewingKey::new(&env, &info, &prng_seed, &(entropy).as_ref());
+        let address = deps.api.addr_canonicalize(&info.sender.as_str())?;
         save_viewing_key(deps, address.as_slice(), &key)?;
 
-        Ok(HandleResponse {
-            messages: vec![],
-            log: vec![],
-            data: Some(to_binary(&AuthHandleAnswer::CreateViewingKey {
-                key
-            })?)
-        })
+        Ok(Response::new()
+            .set_data(to_binary(&AuthHandleAnswer::CreateViewingKey { key })?)
+        )
     }
 
     #[handle]
-    fn set_viewing_key(key: String, _padding: Option<String>) -> StdResult<HandleResponse> {
+    fn set_viewing_key(key: String, _padding: Option<String>) -> StdResult<Response> {
         let key = ViewingKey(key);
-        let address = deps.api.canonical_address(&env.message.sender)?;
+        let address = deps.api.addr_canonicalize(&info.sender.as_str())?;
         save_viewing_key(deps, address.as_slice(), &key)?;
 
-        Ok(HandleResponse::default())
+        Ok(Response::default())
     }
 }
 
@@ -51,24 +47,24 @@ pub enum AuthHandleAnswer {
 }
 
 #[inline]
-pub fn save_viewing_key<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+pub fn save_viewing_key(
+    deps: DepsMut,
     key: &[u8],
     viewing_key: &ViewingKey
 ) -> StdResult<()> {
-    ns_save(&mut deps.storage, VIEWING_KEYS, key, &viewing_key)
+    ns_save(deps.storage, VIEWING_KEYS, key, &viewing_key)
 }
 
 #[inline]
-pub fn load_viewing_key<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+pub fn load_viewing_key(
+    deps: Deps,
     key: &[u8],
 ) -> StdResult<Option<ViewingKey>> {
-    ns_load(&deps.storage, VIEWING_KEYS, key)
+    ns_load(deps.storage, VIEWING_KEYS, key)
 }
 
 pub fn authenticate(
-    storage: &impl Storage,
+    storage: &dyn Storage,
     provided_key: &ViewingKey,
     storage_key: &[u8]
 ) -> StdResult<()> {
@@ -82,26 +78,27 @@ pub fn authenticate(
 
     provided_key.check_viewing_key(&[0u8; VIEWING_KEY_SIZE]);
 
-    return Err(StdError::unauthorized());
+    return Err(StdError::generic_err("Unauthorized"));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm_std::{from_binary, HumanAddr};
-    use cosmwasm_std::testing::{mock_dependencies, mock_env};
+    use cosmwasm_std::{Api, from_binary};
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 
     #[test]
     fn test_handle() {
-        let ref mut deps = mock_dependencies(10, &[]);
+        let ref mut deps = mock_dependencies(&[]);
 
-        let sender = HumanAddr("sender".into());
-        let sender_canonical = deps.api.canonical_address(&sender).unwrap();
-        let env = mock_env(sender, &[]);
+        let sender = "sender";
+        let sender_canonical = deps.api.addr_canonicalize(&sender).unwrap();
+        let env = mock_env();
 
         let result = handle(
-            deps,
+            deps.as_mut(),
             env.clone(),
+            mock_info(sender, &[]),
             HandleMsg::CreateViewingKey { entropy: "123".into(), padding: None },
             DefaultImpl
         ).unwrap();
@@ -113,10 +110,10 @@ mod tests {
             }
         };
         
-        assert_eq!(created_vk, load_viewing_key(deps, sender_canonical.as_slice()).unwrap().unwrap());
+        assert_eq!(created_vk, load_viewing_key(deps.as_ref(), sender_canonical.as_slice()).unwrap().unwrap());
 
         let auth_result = authenticate(&deps.storage, &ViewingKey("invalid".into()), sender_canonical.as_slice());
-        assert_eq!(auth_result.unwrap_err(), StdError::unauthorized());
+        assert_eq!(auth_result.unwrap_err(), StdError::generic_err("Unauthorized"));
 
         let auth_result = authenticate(&deps.storage, &created_vk, sender_canonical.as_slice());
         assert!(auth_result.is_ok());
@@ -124,13 +121,14 @@ mod tests {
         let new_key = String::from("new_key");
 
         handle(
-            deps,
-            env.clone(),
+            deps.as_mut(),
+            env,
+            mock_info(sender, &[]),
             HandleMsg::SetViewingKey { key: new_key.clone(), padding: None },
             DefaultImpl
         ).unwrap();
 
-        assert_eq!(ViewingKey(new_key.clone()), load_viewing_key(deps, sender_canonical.as_slice()).unwrap().unwrap());
+        assert_eq!(ViewingKey(new_key.clone()), load_viewing_key(deps.as_ref(), sender_canonical.as_slice()).unwrap().unwrap());
 
         let auth_result = authenticate(&deps.storage, &ViewingKey(new_key), sender_canonical.as_slice());
         assert!(auth_result.is_ok());


### PR DESCRIPTION
Integrate Fadroma with cosmwasm 0.16.

Changes:

- [x] Compile Fadroma using the `stargate-cosmwasm-v0.16`
- [x] Generate cosmwasm 0.16 API boilerplate in `derive-contract`
- [x] Consume `self` in the `Humanize` trait definition.
- [ ] Remove the `secret-toolkit` crate dependency. It is only being used for the `scrt-snip20-api` feature.