### PR TITLE
replaces missing tag

### DIFF
--- a/crates/fadroma-platform-scrt/Cargo.toml
+++ b/crates/fadroma-platform-scrt/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib.rs"
 [dependencies]
 secret-cosmwasm-std = "0.10.0"
 secret-cosmwasm-storage = "0.10.0"
-cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "secret-cosmwasm-v0.10.0" }
+cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
 schemars = { version = "0.7" }
 secret-toolkit = "0.2.0"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }


### PR DESCRIPTION
For some reason, Secret Labs got rid of the "secret-cosmwasm-v0.10.0" tag on their repo so fadroma-platform-scrt was failing to build. 

Opened this PR in case the tag needs to be reverted to an old working one.