### PR TITLE
clened up imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ doc/typedoc
 .yarn
 coverage
 .pnpm-debug.log
+.idea/

--- a/crates/fadroma-composability/Cargo.toml
+++ b/crates/fadroma-composability/Cargo.toml
@@ -14,4 +14,4 @@ serde                 = { version = "1.0.103", default-features = false, feature
 
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
-fadroma-platform-scrt = { path = "../fadroma-platform-scrt", features = ["iterator"] }
+fadroma-platform-scrt = { path = "../fadroma-platform-scrt" }

--- a/crates/fadroma-ensemble/Cargo.toml
+++ b/crates/fadroma-ensemble/Cargo.toml
@@ -10,5 +10,5 @@ path = "lib.rs"
 
 [dependencies]
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-fadroma-platform-scrt = { path = "../fadroma-platform-scrt", features = ["iterator"] }
+fadroma-platform-scrt = { path = "../fadroma-platform-scrt" }
 fadroma-storage       = { path = "../fadroma-storage" }

--- a/crates/fadroma-platform-scrt/Cargo.toml
+++ b/crates/fadroma-platform-scrt/Cargo.toml
@@ -11,29 +11,27 @@ authors = [
 path = "lib.rs"
 
 [dependencies]
-secret-cosmwasm-std = "0.10.0"
-secret-cosmwasm-storage = "0.10.0"
-cosmwasm-schema = "0.10.1"
-schemars = { version = "0.7" }
-secret-toolkit = "0.2.0"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+schemars = { version = "0.7" }
+
+cosmwasm-std = { version = "0.10", package = "secret-cosmwasm-std" }
+cosmwasm-storage = { version = "0.10", package = "secret-cosmwasm-storage" }
+secret-toolkit = "0.2.0"
+
+[dev-dependencies]
+cosmwasm-schema = "0.10.1"
 
 [features]
 default = []
-# iterator allows us to iterate over all DB items in a given range
-# optional as some merkle stores (like tries) don't support this
-# given Ethereum 1.0, 2.0, Substrate, and other major projects use Tries
-# we keep this optional, to allow possible future integration (or different Cosmos Backends)
-iterator = ["secret-cosmwasm-std/iterator", "secret-cosmwasm-storage/iterator"]
 # staking exposes bindings to a required staking moudle in the runtime, via new
 # CosmosMsg types, and new QueryRequest types. This should only be enabled on contracts
 # that require these types, so other contracts can be used on systems with eg. PoA consensus
-staking = ["secret-cosmwasm-std/staking"]
+staking = ["cosmwasm-std/staking"]
 # backtraces provides much better context at runtime errors (in non-wasm code)
 # at the cost of a bit of code size and performance.
-backtraces = ["secret-cosmwasm-std/backtraces"]
+backtraces = ["cosmwasm-std/backtraces"]
 # Debug prints enable printing log messages to the logging system of the enclave
 # from inside your contract. This will only work in enclaves compiled in SW mode
 # and loading the contract for execution will fail if this is used a HW mode
 # enclave. This is done in order to provent leaking secrets in production.
-debug-print = ["secret-cosmwasm-std/debug-print"]
+debug-print = ["cosmwasm-std/debug-print"]

--- a/crates/fadroma-platform-scrt/lib.rs
+++ b/crates/fadroma-platform-scrt/lib.rs
@@ -1,21 +1,21 @@
-pub use secret_cosmwasm_std as cosmwasm_std;
+pub use cosmwasm_std;
 pub use cosmwasm_std::*;
 
-pub use secret_cosmwasm_storage as cosmwasm_storage;
+pub use cosmwasm_storage;
 pub use cosmwasm_storage::*;
 
 #[cfg(not(target_arch="wasm32"))]
-pub use secret_cosmwasm_std::testing;
+pub use cosmwasm_std::testing;
 
 #[cfg(not(target_arch="wasm32"))]
-pub use secret_cosmwasm_std::testing::*;
-
-pub use cosmwasm_schema;
-pub use cosmwasm_schema::*;
+pub use cosmwasm_std::testing::*;
 
 pub use serde;
 pub use schemars;
 pub use secret_toolkit;
+
+#[cfg(test)]
+pub use cosmwasm_schema::{*, self};
 
 pub const BLOCK_SIZE: usize = 256;
 

--- a/crates/fadroma-platform-terra/Cargo.toml
+++ b/crates/fadroma-platform-terra/Cargo.toml
@@ -12,7 +12,7 @@ path = "terra.rs"
 
 [dependencies]
 # TODO put versions of cosmwasm here
-#cosmwasm-schema   = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
+#cosmwasm-schema   = "0.10.1"
 #cosmwasm-std      = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
 #cosmwasm-storage  = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print", features = ["iterator"] }
 #schemars          = { version = "0.7" }


### PR DESCRIPTION
Hi Fadroma!
This PR just cleans up some of the imports in the crate and adds `.idea/` to the `.gitignore` (this directory is created by jetbrains IDEs)
I also removed the `iterator` feature as it's not supported on Secret Network