### PR TITLE
BREAKING CHANGE: Refactor Humanize/Canonize traits.

### DIFF
--- a/crates/fadroma-composability/composable.rs
+++ b/crates/fadroma-composability/composable.rs
@@ -30,8 +30,8 @@ pub trait Composable<S, A, Q>: BaseComposable<S, A, Q> {
     fn get    <Value: DeserializeOwned> (&self, key: &[u8]) -> Eventually<Value>;
     fn get_ns <Value: DeserializeOwned> (&self, ns: &[u8], key: &[u8]) -> Eventually<Value>;
 
-    fn humanize <Value: Humanize<U>, U: Canonize<Value>> (&self, value: Value) -> StdResult<U>;
-    fn canonize <Value: Canonize<U>, U: Humanize<Value>> (&self, value: Value) -> StdResult<U>;
+    fn humanize <Value: Humanize> (&self, value: Value) -> StdResult<Value::Output>;
+    fn canonize <Value: Canonize> (&self, value: Value) -> StdResult<Value::Output>;
 }
 
 #[macro_export] macro_rules! make_composable {
@@ -78,14 +78,14 @@ pub trait Composable<S, A, Q>: BaseComposable<S, A, Q> {
                 self.get(&concat(ns, key))
             }
 
-            fn humanize <Value: Humanize<U>, U: Canonize<Value>> (&self, value: Value)
-                -> StdResult<U>
+            fn humanize <Value: Humanize> (&self, value: Value)
+                -> StdResult<Value::Output>
             {
                 value.humanize(&self.api)
             }
 
-            fn canonize <Value: Canonize<U>, U: Humanize<Value>> (&self, value: Value)
-                -> StdResult<U>
+            fn canonize <Value: Canonize> (&self, value: Value)
+                -> StdResult<Value::Output>
             {
                 value.canonize(&self.api)
             }

--- a/crates/fadroma-killswitch/killswitch.rs
+++ b/crates/fadroma-killswitch/killswitch.rs
@@ -125,27 +125,27 @@ impl<A> Default for ContractStatus<A> {
         new_address: None
     } }
 }
-impl Humanize<ContractStatus<HumanAddr>> for ContractStatus<CanonicalAddr> {
-    fn humanize (&self, api: &impl Api) -> StdResult<ContractStatus<HumanAddr>> {
+
+impl Humanize for ContractStatus<CanonicalAddr> {
+    type Output = ContractStatus<HumanAddr>;
+
+    fn humanize(self, api: &impl Api) -> StdResult<Self::Output> {
         Ok(ContractStatus {
-            level: self.level.clone(),
-            reason: self.reason.clone(),
-            new_address: match &self.new_address {
-                Some(canon_addr) => Some(api.human_address(&canon_addr)?),
-                None => None
-            }
+            level: self.level,
+            reason: self.reason,
+            new_address: self.new_address.humanize(api)?
         })
     }
 }
-impl Canonize<ContractStatus<CanonicalAddr>> for ContractStatus<HumanAddr> {
-    fn canonize (&self, api: &impl Api) -> StdResult<ContractStatus<CanonicalAddr>> {
+
+impl Canonize for ContractStatus<HumanAddr> {
+    type Output = ContractStatus<CanonicalAddr>;
+
+    fn canonize(self, api: &impl Api) -> StdResult<Self::Output> {
         Ok(ContractStatus {
-            level: self.level.clone(),
-            reason: self.reason.clone(),
-            new_address: match &self.new_address {
-                Some(human_addr) => Some(api.canonical_address(&human_addr)?),
-                None => None
-            }
+            level: self.level,
+            reason: self.reason,
+            new_address: self.new_address.canonize(api)?
         })
     }
 }

--- a/crates/fadroma-platform-scrt/callback.rs
+++ b/crates/fadroma-platform-scrt/callback.rs
@@ -1,6 +1,11 @@
-use crate::*;
+use secret_cosmwasm_std::{StdResult, HumanAddr, CanonicalAddr, Api, Binary};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+use crate::{
+    addr::{Humanize, Canonize},
+    link::ContractLink
+};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -11,13 +16,25 @@ pub struct Callback<A> {
     /// Info about the contract requesting the callback.
     pub contract: ContractLink<A>
 }
-impl Canonize<Callback<CanonicalAddr>> for Callback<HumanAddr> {
-    fn canonize (&self, api: &impl Api) -> StdResult<Callback<CanonicalAddr>> {
-        Ok(Callback { msg: self.msg.clone(), contract: self.contract.canonize(api)? })
+
+impl Humanize for Callback<CanonicalAddr> {
+    type Output = Callback<HumanAddr>;
+
+    fn humanize(self, api: &impl Api) -> StdResult<Self::Output> {
+        Ok(Callback {
+            msg: self.msg,
+            contract: self.contract.humanize(api)?
+        })
     }
 }
-impl Humanize<Callback<HumanAddr>> for Callback<CanonicalAddr> {
-    fn humanize (&self, api: &impl Api) -> StdResult<Callback<HumanAddr>> {
-        Ok(Callback { msg: self.msg.clone(), contract: self.contract.humanize(api)? })
+
+impl Canonize for Callback<HumanAddr> {
+    type Output = Callback<CanonicalAddr>;
+
+    fn canonize(self, api: &impl Api) -> StdResult<Self::Output> {
+        Ok(Callback {
+            msg: self.msg,
+            contract: self.contract.canonize(api)?
+        })
     }
 }

--- a/crates/fadroma-platform-scrt/link.rs
+++ b/crates/fadroma-platform-scrt/link.rs
@@ -1,6 +1,8 @@
-use crate::*;
+use secret_cosmwasm_std::{StdResult, HumanAddr, CanonicalAddr, Api, Env};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+use crate::addr::{Humanize, Canonize};
 
 pub type CodeId   = u64;
 pub type CodeHash = String;
@@ -41,23 +43,28 @@ impl<A: PartialEq> PartialEq for ContractLink<A> {
     }
 }
 
-impl Canonize<ContractLink<CanonicalAddr>> for ContractLink<HumanAddr> {
-    fn canonize (&self, api: &impl Api) -> StdResult<ContractLink<CanonicalAddr>> {
+impl Humanize for ContractLink<CanonicalAddr> {
+    type Output = ContractLink<HumanAddr>;
+
+    fn humanize(self, api: &impl Api) -> StdResult<Self::Output> {
         Ok(ContractLink {
-            address:   self.address.canonize(api)?,
-            code_hash: self.code_hash.clone()
+            address: self.address.humanize(api)?,
+            code_hash: self.code_hash
         })
     }
 }
 
-impl Humanize<ContractLink<HumanAddr>> for ContractLink<CanonicalAddr> {
-    fn humanize (&self, api: &impl Api) -> StdResult<ContractLink<HumanAddr>> {
+impl Canonize for ContractLink<HumanAddr> {
+    type Output = ContractLink<CanonicalAddr>;
+
+    fn canonize(self, api: &impl Api) -> StdResult<Self::Output> {
         Ok(ContractLink {
-            address:   self.address.humanize(api)?,
-            code_hash: self.code_hash.clone()
+            address: self.address.canonize(api)?,
+            code_hash: self.code_hash
         })
     }
 }
+
 impl From<Env> for ContractLink<HumanAddr> {
     fn from (env: Env) -> ContractLink<HumanAddr> {
         ContractLink {


### PR DESCRIPTION
Re-wrote the `Humanize`/`Canonize` traits in a way which brings the following new benefits:
 - More straightforward/less confusing implementation. The old definitions required the user type the same type multiple times in a way that was confusing.
 - Cloning is now opt-in and not hidden. The old implementations took a reference to `self` but in reality called `clone()` when converting. This was because it cloned the struct when it might not have been necessary (especially when converting from canonical to humanized version). It also broke the contract of `&self` where the assumption usually is that no memory copying is necessary. Now if the user wants to use the struct after calling `humanize`/`canonize` they can explicitly do so by calling `clone()` before that. Overall, this gives more control over to the programmer and removes hidden costs.
 - The bi-directional relationship between the human and canonical version of the struct is now enforced on the type level and will result in a compile error if violated. In other words, if we implement `Canonize` for `MyStruct<HumanAddr>` we are now forced to implement `Humanize` for `MyStruct<CanonicalAddr>` and vice versa.