### PR TITLE
Multilevel namespaces and remove functions

### DIFF
--- a/crates/fadroma-composability/composable.rs
+++ b/crates/fadroma-composability/composable.rs
@@ -7,63 +7,92 @@
 //!   directly. However this introduces a clash between `Storage::get/set` and
 //!   `Composable::get/set`, therefor the latter will need to be renamed once again
 
+use crate::namespace_helpers::{key_prefix, key_prefix_nested};
 use fadroma_platform_scrt::*;
 use fadroma_storage::*;
-
-use serde::{Serialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Serialize};
 
 pub type UsuallyOk = StdResult<()>;
 
 pub type Eventually<Value> = StdResult<Option<Value>>;
 
 pub trait BaseComposable<S, A, Q> {
-    fn storage     (&self)     -> &S;
-    fn storage_mut (&mut self) -> &mut S;
-    fn api         (&self)     -> &A;
-    fn querier     (&self)     -> &Q;
+    fn storage(&self) -> &S;
+    fn storage_mut(&mut self) -> &mut S;
+    fn api(&self) -> &A;
+    fn querier(&self) -> &Q;
 }
 
 pub trait Composable<S, A, Q>: BaseComposable<S, A, Q> {
-    fn set    <Value: Serialize> (&mut self, key: &[u8], value: Value) -> UsuallyOk;
-    fn set_ns <Value: Serialize> (&mut self, ns: &[u8], key: &[u8], value: Value) -> UsuallyOk;
+    fn set<Value: Serialize>(&mut self, key: &[u8], value: Value) -> UsuallyOk;
+    /// Uses a single slice as namespace and it combines it with the key
+    fn set_ns<Value: Serialize>(&mut self, ns: &[u8], key: &[u8], value: Value) -> UsuallyOk;
+    /// Uses an array of slices which are then combined according to the following spec:
+    /// https://github.com/webmaster128/key-namespacing#nesting
+    fn set_multi_ns<Value: Serialize>(
+        &mut self,
+        ns: &[&[u8]],
+        key: &[u8],
+        value: Value,
+    ) -> UsuallyOk;
 
-    fn get    <Value: DeserializeOwned> (&self, key: &[u8]) -> Eventually<Value>;
-    fn get_ns <Value: DeserializeOwned> (&self, ns: &[u8], key: &[u8]) -> Eventually<Value>;
+    fn get<Value: DeserializeOwned>(&self, key: &[u8]) -> Eventually<Value>;
+    fn get_ns<Value: DeserializeOwned>(&self, ns: &[u8], key: &[u8]) -> Eventually<Value>;
+    fn get_multi_ns<Value: DeserializeOwned>(&self, ns: &[&[u8]], key: &[u8]) -> Eventually<Value>;
 
-    fn humanize <Value: Humanize> (&self, value: Value) -> StdResult<Value::Output>;
-    fn canonize <Value: Canonize> (&self, value: Value) -> StdResult<Value::Output>;
+    fn remove(&mut self, key: &[u8]) -> UsuallyOk;
+    fn remove_ns(&mut self, ns: &[u8], key: &[u8]) -> UsuallyOk;
+    fn remove_multi_ns(&mut self, ns: &[&[u8]], key: &[u8]) -> UsuallyOk;
+
+    fn humanize<Value: Humanize>(&self, value: Value) -> StdResult<Value::Output>;
+    fn canonize<Value: Canonize>(&self, value: Value) -> StdResult<Value::Output>;
 }
 
-#[macro_export] macro_rules! make_composable {
-
+#[macro_export]
+macro_rules! make_composable {
     ($Struct:ty) => {
-
         // base trait with no generic methods, in order to to support `dyn`
         impl<S: Storage, A: Api, Q: Querier> BaseComposable<S, A, Q> for $Struct {
-            fn storage     (&self)     -> &S { &self.storage }
-            fn storage_mut (&mut self) -> &mut S { &mut self.storage }
-            fn api         (&self)     -> &A { &self.api }
-            fn querier     (&self)     -> &Q { &self.querier }
+            fn storage(&self) -> &S {
+                &self.storage
+            }
+            fn storage_mut(&mut self) -> &mut S {
+                &mut self.storage
+            }
+            fn api(&self) -> &A {
+                &self.api
+            }
+            fn querier(&self) -> &Q {
+                &self.querier
+            }
         }
 
         impl<S: Storage, A: Api, Q: Querier> Composable<S, A, Q> for $Struct {
-
-            fn set <Value: serde::Serialize> (&mut self, key: &[u8], value: Value)
-                -> UsuallyOk
-            {
+            fn set<Value: serde::Serialize>(&mut self, key: &[u8], value: Value) -> UsuallyOk {
                 self.storage.set(key, &to_vec(&Some(value))?);
                 Ok(())
             }
 
-            fn set_ns <Value: serde::Serialize> (&mut self, ns: &[u8], key: &[u8], value: Value)
-                -> UsuallyOk
-            {
-                self.set(&concat(ns, key), value)
+            fn set_ns<Value: serde::Serialize>(
+                &mut self,
+                ns: &[u8],
+                key: &[u8],
+                value: Value,
+            ) -> UsuallyOk {
+                let ns = key_prefix(ns);
+                self.set(&concat(&ns, key), value)
+            }
+            fn set_multi_ns<Value: serde::Serialize>(
+                &mut self,
+                ns: &[&[u8]],
+                key: &[u8],
+                value: Value,
+            ) -> UsuallyOk {
+                let ns = key_prefix_nested(ns);
+                self.set(&concat(&ns, key), value)
             }
 
-            fn get <Value: serde::de::DeserializeOwned> (&self, key: &[u8])
-                -> Eventually<Value>
-            {
+            fn get<Value: serde::de::DeserializeOwned>(&self, key: &[u8]) -> Eventually<Value> {
                 if let Some(data) = self.storage.get(key) {
                     Ok(from_slice(&data)?)
                 } else {
@@ -72,27 +101,45 @@ pub trait Composable<S, A, Q>: BaseComposable<S, A, Q> {
                 }
             }
 
-            fn get_ns <Value: serde::de::DeserializeOwned> (&self, ns: &[u8], key: &[u8])
-                -> Eventually<Value>
-            {
-                self.get(&concat(ns, key))
+            fn get_ns<Value: serde::de::DeserializeOwned>(
+                &self,
+                ns: &[u8],
+                key: &[u8],
+            ) -> Eventually<Value> {
+                let ns = key_prefix(ns);
+                self.get(&concat(&ns, key))
+            }
+            fn get_multi_ns<Value: serde::de::DeserializeOwned>(
+                &self,
+                ns: &[&[u8]],
+                key: &[u8],
+            ) -> Eventually<Value> {
+                let ns = key_prefix_nested(ns);
+                self.get(&concat(&ns, key))
             }
 
-            fn humanize <Value: Humanize> (&self, value: Value)
-                -> StdResult<Value::Output>
-            {
+            fn remove(&mut self, key: &[u8]) -> UsuallyOk {
+                self.storage.remove(key);
+                Ok(())
+            }
+            fn remove_ns(&mut self, ns: &[u8], key: &[u8]) -> UsuallyOk {
+                let ns = key_prefix(ns);
+                self.remove(&concat(&ns, key))
+            }
+            fn remove_multi_ns(&mut self, ns: &[&[u8]], key: &[u8]) -> UsuallyOk {
+                let ns = key_prefix_nested(ns);
+                self.remove(&concat(&ns, key))
+            }
+
+            fn humanize<Value: Humanize>(&self, value: Value) -> StdResult<Value::Output> {
                 value.humanize(&self.api)
             }
 
-            fn canonize <Value: Canonize> (&self, value: Value)
-                -> StdResult<Value::Output>
-            {
+            fn canonize<Value: Canonize>(&self, value: Value) -> StdResult<Value::Output> {
                 value.canonize(&self.api)
             }
-
         }
-
-    }
+    };
 }
 
 make_composable!(Extern<S, A, Q>);

--- a/crates/fadroma-composability/lib.rs
+++ b/crates/fadroma-composability/lib.rs
@@ -1,11 +1,16 @@
 pub mod composable;
 pub use composable::*;
 
-#[cfg(not(target_arch="wasm32"))] pub mod composable_test;
-#[cfg(not(target_arch="wasm32"))] pub use composable_test::*;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod composable_test;
+#[cfg(not(target_arch = "wasm32"))]
+pub use composable_test::*;
 
 pub mod dispatch;
 pub use dispatch::*;
 
 pub mod response;
 pub use response::*;
+
+mod namespace_helpers;
+use namespace_helpers::*;

--- a/crates/fadroma-composability/namespace_helpers.rs
+++ b/crates/fadroma-composability/namespace_helpers.rs
@@ -1,0 +1,38 @@
+// Calculates the raw key prefix for a given namespace
+// as documented in https://github.com/webmaster128/key-namespacing#length-prefixed-keys
+pub fn key_prefix(namespace: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(namespace.len() + 2);
+    extend_with_prefix(&mut out, namespace);
+    out
+}
+
+// Calculates the raw key prefix for a given nested namespace
+// as documented in https://github.com/webmaster128/key-namespacing#nesting
+pub fn key_prefix_nested(namespaces: &[&[u8]]) -> Vec<u8> {
+    let mut size = namespaces.len();
+    for &namespace in namespaces {
+        size += namespace.len() + 2;
+    }
+
+    let mut out = Vec::with_capacity(size);
+    for &namespace in namespaces {
+        extend_with_prefix(&mut out, namespace);
+    }
+    out
+}
+
+// extend_with_prefix is only for internal use to unify key_prefix and key_prefix_nested efficiently
+// as documented in https://github.com/webmaster128/key-namespacing#nesting
+fn extend_with_prefix(out: &mut Vec<u8>, namespace: &[u8]) {
+    out.extend_from_slice(&key_len(namespace));
+    out.extend_from_slice(namespace);
+}
+
+// returns the length as a 2 byte big endian encoded integer
+fn key_len(prefix: &[u8]) -> [u8; 2] {
+    if prefix.len() > 0xFFFF {
+        panic!("only supports namespaces up to length 0xFFFF")
+    }
+    let length_bytes = (prefix.len() as u64).to_be_bytes();
+    [length_bytes[6], length_bytes[7]]
+}


### PR DESCRIPTION
The following PR adds `remove` functions to the composability API as well as logic for dynamically building nested namespaces. The logic behind nested namesapces is taken from the following [repo](https://github.com/webmaster128/key-namespacing#nesting)  
What this solves is prevent potential namespace conflicts between the composed contracts. 
The API is used as following: 
```rust
core.set_multi_ns(
            &[SLICE1, SLICE2, SLICE3],
            KEY,
            VALUE
);
```
Supports, `GET`,`SET` and `REMOVE`
