### PR TITLE
BREAKING CHANGE: Remove need for user to box when registering a harness with an ensemble

### DIFF
--- a/crates/fadroma-ensemble/tests.rs
+++ b/crates/fadroma-ensemble/tests.rs
@@ -234,8 +234,8 @@ fn init(
     fail_counter: bool,
     fail_multiplier: bool
 ) -> StdResult<InitResult> {
-    let counter = ensemble.register(Box::new(Counter));
-    let multiplier = ensemble.register(Box::new(Multiplier));
+    let counter = ensemble.register(Counter);
+    let multiplier = ensemble.register(Multiplier);
 
     let admin = "admin";
     ensemble.add_funds(admin, vec![ coin(SEND_AMOUNT, SEND_DENOM) ]);

--- a/examples/ensemble/src/lib.rs
+++ b/examples/ensemble/src/lib.rs
@@ -84,8 +84,8 @@ impl ContractHarness for TestContract {
 fn test_contracts() {
     use fadroma::ContractLink;
     let mut ensemble = ContractEnsemble::new(50);
-    let oracle = ensemble.register(Box::new(Oracle));
-    let test_contract = ensemble.register(Box::new(TestContract));
+    let oracle = ensemble.register(Oracle);
+    let test_contract = ensemble.register(TestContract);
 
     let oracle = ensemble
         .instantiate(


### PR DESCRIPTION
### Breaking Change:
Simplified the public API for `ContractEnsemble` by removing the need for the user to explicitly `Box` a type implementing `ContractHarness` when registering. 

```rust
// this
let mut ensemble = ContractEnsemble::new(50);
let oracle = ensemble.register(Box::new(Oracle));
let test_contract = ensemble.register(Box::new(TestContract));

// becomes
let mut ensemble = ContractEnsemble::new(50);
let oracle = ensemble.register(Oracle);
let test_contract = ensemble.register(TestContract);
```
### Internal Change:
Removed redundant `Box` from the `ContractEnsemble::ctx` field.