### PR TITLE
Ensemble execute and instantiate returns appropriate response data

### DIFF
--- a/crates/fadroma/ensemble/bank.rs
+++ b/crates/fadroma/ensemble/bank.rs
@@ -6,6 +6,13 @@ pub type Balances = HashMap<String, Uint128>;
 #[derive(Clone, Default, Debug)]
 pub(crate) struct Bank(pub(crate) HashMap<HumanAddr, Balances>);
 
+#[derive(Debug)]
+pub struct CosmosBankResponse {
+    pub sender: HumanAddr,
+    pub receiver: HumanAddr,
+    pub coins: Vec<Coin>
+}
+
 impl Bank {
     pub fn add_funds(&mut self, address: &HumanAddr, coins: Vec<Coin>) {
         if coins.is_empty() {
@@ -26,9 +33,15 @@ impl Bank {
         from: &HumanAddr,
         to: &HumanAddr,
         coins: Vec<Coin>,
-    ) -> StdResult<()> {
+    ) -> StdResult<CosmosBankResponse> {
+        let res = CosmosBankResponse {
+            sender: from.clone(),
+            receiver: to.clone(),
+            coins: coins.clone()
+        };
+
         if coins.is_empty() {
-            return Ok(());
+            return Ok(res);
         }
 
         self.assert_account_exists(from);
@@ -60,7 +73,7 @@ impl Bank {
             add_balance(self.0.get_mut(to).unwrap(), coin);
         }
 
-        Ok(())
+        Ok(res)
     }
 
     pub fn query_balances(&self, address: &HumanAddr, denom: Option<String>) -> Vec<Coin> {

--- a/crates/fadroma/ensemble/block.rs
+++ b/crates/fadroma/ensemble/block.rs
@@ -58,7 +58,7 @@ impl Block {
     /// # Examples
     /// 
     /// ```
-    /// use fadroma_ensemble::Block;
+    /// use fadroma::ensemble::Block;
     /// 
     /// let mut block = Block::default();
     /// block.exact_increments(1, 5);
@@ -82,7 +82,7 @@ impl Block {
     /// # Examples
     /// 
     /// ```
-    /// use fadroma_ensemble::Block;
+    /// use fadroma::ensemble::Block;
     /// 
     /// let mut block = Block::default();
     /// block.exact_increments(1, 5);

--- a/crates/fadroma/ensemble/ensemble.rs
+++ b/crates/fadroma/ensemble/ensemble.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use crate::ensemble::bank::CosmosBankResponse;
 use super::{
     bank::{Balances, Bank},
     env::MockEnv,
@@ -40,6 +41,31 @@ pub(crate) struct Context {
 pub(crate) struct ContractInstance {
     pub(crate) deps: MockDeps,
     index: usize
+}
+
+#[derive(Debug)]
+pub struct ExecuteResponse {
+    pub sender: HumanAddr,
+    pub target: HumanAddr,
+    pub msg: Binary,
+    pub response: HandleResponse,
+    pub sent: Vec<Response>
+}
+
+#[derive(Debug)]
+pub struct InstantiateResponse {
+    pub sender: HumanAddr,
+    pub instantiation: ContractLink<HumanAddr>,
+    pub msg: Binary,
+    pub response: InitResponse,
+    pub sent: Vec<Response>
+}
+
+#[derive(Debug)]
+pub enum Response {
+    WasmExecute { res: ExecuteResponse },
+    WasmInstantiate { res: InstantiateResponse },
+    CosmosBank { res: CosmosBankResponse }
 }
 
 impl ContractEnsemble {
@@ -134,7 +160,7 @@ impl ContractEnsemble {
         id: u64,
         msg: &T,
         env: MockEnv,
-    ) -> StdResult<ContractLink<HumanAddr>> {
+    ) -> StdResult<InstantiateResponse> {
         let result = self.ctx.instantiate(id as usize, to_binary(msg)?, env);
 
         if result.is_ok() {
@@ -152,7 +178,7 @@ impl ContractEnsemble {
         &mut self,
         msg: &T,
         env: MockEnv
-    ) -> StdResult<HandleResponse> {
+    ) -> StdResult<ExecuteResponse> {
         let result = self.ctx.execute(to_binary(msg)?, env);
 
         if result.is_ok() {
@@ -217,7 +243,7 @@ impl Context {
         id: usize,
         msg: Binary,
         env: MockEnv,
-    ) -> StdResult<ContractLink<HumanAddr>> {
+    ) -> StdResult<InstantiateResponse> {
         let contract = self.contracts.get(id)
             .expect(&format!("Contract with id \"{}\" doesn't exist.", id));
 
@@ -240,17 +266,25 @@ impl Context {
         self.instances.insert(contract_info.address.clone(), instance);
 
         let env = self.create_env(env);
+        let sender = env.message.sender.clone();
+
         let instance = self.instances.get_mut(&contract_info.address).unwrap();
 
-        let result = contract.init(&mut instance.deps, env, msg);
+        let result = contract.init(&mut instance.deps, env, msg.clone());
 
         match result {
             Ok(msgs) => {
-                let result = self.execute_messages(msgs.messages, contract_info.address.clone());
+                let result = self.execute_messages(msgs.messages.clone(), contract_info.address.clone());
 
                 match result {
-                    Ok(_) => {
-                        Ok(contract_info)
+                    Ok(sent) => {
+                        Ok(InstantiateResponse {
+                            sender,
+                            instantiation: contract_info,
+                            msg,
+                            response: msgs,
+                            sent
+                        })
                     }
                     Err(err) => {
                         self.instances.remove(&contract_info.address);
@@ -267,9 +301,11 @@ impl Context {
         }
     }
 
-    fn execute(&mut self, msg: Binary, env: MockEnv) -> StdResult<HandleResponse> {
+    fn execute(&mut self, msg: Binary, env: MockEnv) -> StdResult<ExecuteResponse> {
+
         let address = env.contract.address.clone();
         let env = self.create_env(env);
+        let sender = env.message.sender.clone();
 
         let instance = self
             .instances
@@ -277,17 +313,26 @@ impl Context {
             .expect(&format!("Contract address doesn't exist: {}", address));
 
         self.bank.writable().transfer(
-            &env.message.sender,
+            &sender,
             &address,
             env.message.sent_funds.clone(),
         )?;
 
         let contract = self.contracts.get(instance.index).unwrap();
-        let result = contract.handle(&mut instance.deps, env, msg)?;
 
-        self.execute_messages(result.messages.clone(), address)?;
+        let result = contract.handle(&mut instance.deps, env, msg.clone())?;
 
-        Ok(result)
+        let sent = self.execute_messages(result.messages.clone(), address.clone())?;
+
+        let res = ExecuteResponse {
+            sender,
+            target: address,
+            msg,
+            response: result,
+            sent
+        };
+
+        Ok(res)
     }
 
     pub(crate) fn query(&self, address: HumanAddr, msg: Binary) -> StdResult<Binary> {
@@ -305,7 +350,8 @@ impl Context {
         &mut self,
         messages: Vec<CosmosMsg>,
         sender: HumanAddr
-    ) -> StdResult<()> {
+    ) -> StdResult<Vec<Response>> {
+        let mut responses = vec![];
         for msg in messages {
             match msg {
                 CosmosMsg::Wasm(msg) => match msg {
@@ -324,7 +370,9 @@ impl Context {
                         )
                         .sent_funds(send);
 
-                        self.execute(msg, env)?;
+                        responses.push(Response::WasmExecute {
+                            res: self.execute(msg, env)?
+                        });
                     }
                     WasmMsg::Instantiate {
                         code_id,
@@ -342,7 +390,9 @@ impl Context {
                         )
                         .sent_funds(send);
 
-                        self.instantiate(code_id as usize, msg, env)?;
+                        responses.push(Response::WasmInstantiate {
+                            res: self.instantiate(code_id as usize, msg, env)?
+                        });
                     }
                 },
                 CosmosMsg::Bank(msg) => match msg {
@@ -351,16 +401,18 @@ impl Context {
                         to_address,
                         amount,
                     } => {
-                        self.bank
+                        let res = self.bank
                             .writable()
                             .transfer(&from_address, &to_address, amount)?;
+
+                        responses.push(Response::CosmosBank { res });
                     }
                 },
                 _ => panic!("Unsupported message: {:?}", msg),
             }
         }
 
-        Ok(())
+        Ok(responses)
     }
 
     fn create_env(&self, env: MockEnv) -> Env {

--- a/crates/fadroma/ensemble/ensemble.rs
+++ b/crates/fadroma/ensemble/ensemble.rs
@@ -152,7 +152,7 @@ impl ContractEnsemble {
         &mut self,
         msg: &T,
         env: MockEnv
-    ) -> StdResult<()> {
+    ) -> StdResult<HandleResponse> {
         let result = self.ctx.execute(to_binary(msg)?, env);
 
         if result.is_ok() {
@@ -267,7 +267,7 @@ impl Context {
         }
     }
 
-    fn execute(&mut self, msg: Binary, env: MockEnv) -> StdResult<()> {
+    fn execute(&mut self, msg: Binary, env: MockEnv) -> StdResult<HandleResponse> {
         let address = env.contract.address.clone();
         let env = self.create_env(env);
 
@@ -285,9 +285,9 @@ impl Context {
         let contract = self.contracts.get(instance.index).unwrap();
         let result = contract.handle(&mut instance.deps, env, msg)?;
 
-        self.execute_messages(result.messages, address)?;
+        self.execute_messages(result.messages.clone(), address)?;
 
-        Ok(())
+        Ok(result)
     }
 
     pub(crate) fn query(&self, address: HumanAddr, msg: Binary) -> StdResult<Binary> {

--- a/crates/fadroma/ensemble/tests.rs
+++ b/crates/fadroma/ensemble/tests.rs
@@ -218,7 +218,7 @@ fn init(
             },
         )
         .sent_funds(vec![coin(SEND_AMOUNT, SEND_DENOM)]),
-    )?;
+    )?.instantiation;
 
     Ok(InitResult {
         counter,
@@ -462,7 +462,7 @@ fn exact_increment() {
                 },
             ),
         )
-        .unwrap();
+        .unwrap().instantiation;
 
     ensemble
         .execute(
@@ -521,7 +521,7 @@ fn random_increment() {
                 },
             ),
         )
-        .unwrap();
+        .unwrap().instantiation;
 
     ensemble
         .execute(
@@ -573,7 +573,7 @@ fn block_freeze() {
             },
         ),
     )
-    .unwrap();
+    .unwrap().instantiation;
 
     ensemble.execute(
         &BlockHeightHandle::Set,


### PR DESCRIPTION
Ensemble contract instantiations and executions now return a structure that describes processed message along with  cross contract interactions that might have occurred.

Additions
 * 'Response' enum contains all possible responses: 'InstantiateResponse', 'ExecuteResponse' and 'CosmosBankResponse'
 * Each of these responses has information that completely describes the action that took place

Changes:
 * `ContractEnsemble.execute()` and `Context.execute()` now returns `StdResult<ExecuteResponse>`
 * `ContractEnsemble.instantiate()` and `Context.instantiate()` now returns `StdResult<InstantiateResponse>`

This is a very useful improvement for those that verify what the contract returned when testing `HandleMsg`s and contract instantiations.