### PR TITLE
Staking/Validator Support

### DIFF
--- a/crates/fadroma/ensemble/bank.rs
+++ b/crates/fadroma/ensemble/bank.rs
@@ -23,6 +23,26 @@ impl Bank {
         }
     }
 
+    pub fn remove_funds(
+        &mut self, 
+        address: &HumanAddr, 
+        coins: Vec<Coin>
+    ) -> StdResult<()> {
+        if coins.is_empty() {
+            return Ok(());
+        }
+        
+        self.assert_account_exists(address);
+
+        let account = self.0.get_mut(address).unwrap();
+
+        for coin in coins {
+            remove_balance(account, coin)?;
+        }
+
+        Ok(())
+    }
+
     pub fn transfer(
         &mut self,
         from: &HumanAddr,
@@ -112,5 +132,20 @@ fn add_balance(balances: &mut Balances, coin: Coin) {
         amount.0 += coin.amount.0;
     } else {
         balances.insert(coin.denom, coin.amount);
+    }
+}
+
+fn remove_balance(balances: &mut Balances, coin: Coin) -> StdResult<()> {
+    let balance = balances.get_mut(&coin.denom);
+
+    if let Some(amount) = balance {
+        if amount.0 > coin.amount.0 {
+            amount.0 -= coin.amount.0;
+            Ok(())
+        } else {
+            Err(StdError::generic_err("Insufficient balance for remove balance"))
+        }
+    } else {
+        Err(StdError::generic_err("Account doesn't exist, cannot remove balance"))
     }
 }

--- a/crates/fadroma/ensemble/bank.rs
+++ b/crates/fadroma/ensemble/bank.rs
@@ -49,15 +49,22 @@ impl Bank {
                         amount.0 -= coin.amount.0;
                     } else {
                         return Err(StdError::generic_err(format!(
-                            "Insufficient {} balance {} for remove balance {}", 
+                            "Insufficient balance: account: {}, denom: {}, balance: {}, required: {}", 
+                            address,
                             coin.denom,
                             amount.0,
-                            coin.amount.0
+                            coin.amount.0,
                         )))
                     }
                 },
                 None => {
-                    return Err(StdError::generic_err(format!("Zero {} balance for remove balance", coin.denom)))
+                    return Err(StdError::generic_err(format!(
+                        "Insufficient balance: account: {}, denom: {}, balance: {}, required: {}",
+                        address,
+                        coin.denom,
+                        Uint128::zero(),
+                        coin.amount.0,
+                    )))
                 }
             }
         }

--- a/crates/fadroma/ensemble/bank.rs
+++ b/crates/fadroma/ensemble/bank.rs
@@ -27,7 +27,7 @@ impl Bank {
         &mut self, 
         address: &HumanAddr, 
         coins: Vec<Coin>
-    ) -> StdResult<()> {
+    ) -> UsuallyOk {
         if coins.is_empty() {
             return Ok(());
         }

--- a/crates/fadroma/ensemble/ensemble.rs
+++ b/crates/fadroma/ensemble/ensemble.rs
@@ -52,9 +52,9 @@ impl ContractEnsemble {
         }
     }
 
-    pub fn new_with_denom(canonical_length: usize, native_denom: String) -> Self {
+    pub fn new_with_denom(canonical_length: usize, native_denom: impl Into<String>) -> Self {
         Self {
-            ctx: Box::new(Context::new(canonical_length, native_denom)),
+            ctx: Box::new(Context::new(canonical_length, native_denom.into())),
         }
     }
 
@@ -430,8 +430,8 @@ impl Context {
                             .remove_funds(&sender, vec![amount.clone()])?;
                         
                         let res = match self.delegations.delegate(
-                            &sender,
-                            &validator,
+                            sender.clone(),
+                            validator,
                             amount.clone(),
                         ) {
                             Ok(result) => Ok(result),
@@ -448,8 +448,8 @@ impl Context {
                         amount,
                     } => {
                         let res = self.delegations.undelegate(
-                            &sender,
-                            &validator,
+                            sender.clone(),
+                            validator,
                             amount.clone(),
                         )?;
                         
@@ -477,8 +477,8 @@ impl Context {
                             .add_funds(&funds_recipient, vec![withdraw_amount]);
 
                         let withdraw_res = self.delegations.withdraw(
-                            &sender,
-                            &validator,
+                            sender.clone(),
+                            validator,
                         )?;
 
                         responses.push(Response::Staking(withdraw_res));
@@ -489,9 +489,9 @@ impl Context {
                         amount,
                     } => {
                         let res = self.delegations.redelegate(
-                            &sender,
-                            &src_validator,
-                            &dst_validator,
+                            sender.clone(),
+                            src_validator,
+                            dst_validator,
                             amount,
                         )?;
 

--- a/crates/fadroma/ensemble/ensemble.rs
+++ b/crates/fadroma/ensemble/ensemble.rs
@@ -112,6 +112,14 @@ impl ContractEnsemble {
         self.ctx.delegations.all_delegations(&address.into())
     }
 
+    pub fn delegation(
+        &self, 
+        delegator: impl Into<HumanAddr>, 
+        validator: impl Into<HumanAddr>
+    ) -> Option<FullDelegation> {
+        self.ctx.delegations.delegation(&delegator.into(), &validator.into())
+    }
+
     #[inline]
     pub fn add_validator(&mut self, validator: Validator) {
         self.ctx.delegations.add_validator(validator);

--- a/crates/fadroma/ensemble/ensemble.rs
+++ b/crates/fadroma/ensemble/ensemble.rs
@@ -10,7 +10,8 @@ use super::{
     revertable::Revertable,
     storage::TestStorage,
     block::Block,
-    response::{Response, InstantiateResponse, ExecuteResponse}
+    response::{Response, InstantiateResponse, ExecuteResponse},
+    staking::Delegations,
 };
 
 pub type MockDeps = Extern<Revertable<TestStorage>, MockApi, EnsembleQuerier>;
@@ -33,6 +34,7 @@ pub(crate) struct Context {
     pub(crate) instances: HashMap<HumanAddr, ContractInstance>,
     pub(crate) contracts: Vec<Box<dyn ContractHarness>>,
     pub(crate) bank: Revertable<Bank>,
+    pub(crate) delegations: Delegations,
     block: Block,
     chain_id: String,
     canonical_length: usize,
@@ -46,7 +48,13 @@ pub(crate) struct ContractInstance {
 impl ContractEnsemble {
     pub fn new(canonical_length: usize) -> Self {
         Self {
-            ctx: Box::new(Context::new(canonical_length)),
+            ctx: Box::new(Context::new(canonical_length, "uscrt".into())),
+        }
+    }
+
+    pub fn new_denom(canonical_length: usize, native_denom: String) -> Self {
+        Self {
+            ctx: Box::new(Context::new(canonical_length, native_denom)),
         }
     }
 
@@ -90,6 +98,16 @@ impl ContractEnsemble {
         self.ctx.bank.current.0.get_mut(&address.into())
     }
 
+    #[inline]
+    pub fn add_validator(&mut self, validator: Validator) {
+        self.ctx.delegations.add_validator(validator);
+    }
+
+    #[inline]
+    pub fn add_rewards(&mut self, amount: Uint128) {
+        self.ctx.delegations.distribute_rewards(amount);
+    }
+
     // Returning a Result here is most flexible and requires the caller to assert that
     // their closure was called, as it is really unlikely that they call this function
     // with an address they know doesn't exist. And we don't want to fail silently if
@@ -107,6 +125,7 @@ impl ContractEnsemble {
 
             return Ok(());
         }
+
 
         Err(format!("Contract not found: {}", address))
     }
@@ -202,12 +221,13 @@ impl ContractInstance {
 }
 
 impl Context {
-    pub fn new(canonical_length: usize) -> Self {
+    pub fn new(canonical_length: usize, native_denom: String) -> Self {
         Self {
             canonical_length,
             bank: Default::default(),
             contracts: Default::default(),
             instances: Default::default(),
+            delegations: Delegations::new(native_denom),
             block: Block::default(),
             chain_id: "fadroma-ensemble-testnet".into()
         }
@@ -238,7 +258,6 @@ impl Context {
             &contract_info.address,
             env.sent_funds.clone(),
         )?;
-
         self.instances.insert(contract_info.address.clone(), instance);
 
         let env = self.create_env(env);
@@ -384,6 +403,73 @@ impl Context {
                         responses.push(Response::Bank(res));
                     }
                 },
+                CosmosMsg::Staking(msg) => match msg {
+                    StakingMsg::Delegate {
+                        validator,
+                        amount,
+                    } => {
+                        let res = self.delegations.delegate(
+                            sender.clone(),
+                            validator,
+                            amount,
+                        )?;
+
+                        responses.push(Response::Staking(res));
+                    }, 
+                    StakingMsg::Undelegate {
+                        validator,
+                        amount,
+                    } => {
+                        let res = self.delegations.undelegate(
+                            sender.clone(),
+                            validator,
+                            amount,
+                        )?;
+
+                        responses.push(Response::Staking(res));
+                    },
+                    StakingMsg::Withdraw {
+                        validator,
+                        recipient,
+                    } => {
+                        // Query accumulated rewards to bank transaction can take place first
+                        let withdraw_amount = match self.delegations.delegation(
+                            sender.clone(),
+                            validator.clone(),
+                        ) {
+                            Some(amount) => amount.accumulated_rewards,
+                            None => return Err(StdError::generic_err("Delegation not found")),
+                        };
+                        
+                        let funds_recipient = match recipient {
+                            Some(recipient) => recipient,
+                            None => sender.clone(),
+                        };
+
+                        self.bank.writable()
+                            .add_funds(&funds_recipient, vec![withdraw_amount]);
+                        let withdraw_res = self.delegations.withdraw(
+                            sender.clone(),
+                            validator,
+                        )?;
+
+                        responses.push(Response::Staking(withdraw_res));
+                    },
+                    StakingMsg::Redelegate {
+                        src_validator,
+                        dst_validator,
+                        amount,
+                    } => {
+                        let res = self.delegations.redelegate(
+                            sender.clone(),
+                            src_validator,
+                            dst_validator,
+                            amount,
+                        )?;
+
+                        responses.push(Response::Staking(res));
+                    },
+                }, 
                 _ => panic!("Unsupported message: {:?}", msg),
             }
         }

--- a/crates/fadroma/ensemble/ensemble.rs
+++ b/crates/fadroma/ensemble/ensemble.rs
@@ -457,6 +457,7 @@ impl Context {
 
                         self.bank.writable()
                             .add_funds(&funds_recipient, vec![withdraw_amount]);
+
                         let withdraw_res = self.delegations.withdraw(
                             &sender,
                             &validator,

--- a/crates/fadroma/ensemble/ensemble.rs
+++ b/crates/fadroma/ensemble/ensemble.rs
@@ -108,6 +108,11 @@ impl ContractEnsemble {
     }
 
     #[inline]
+    pub fn delegations(&self, address: impl Into<HumanAddr>) -> Vec<Delegation> {
+        self.ctx.delegations.all_delegations(&address.into())
+    }
+
+    #[inline]
     pub fn add_validator(&mut self, validator: Validator) {
         self.ctx.delegations.add_validator(validator);
     }

--- a/crates/fadroma/ensemble/ensemble.rs
+++ b/crates/fadroma/ensemble/ensemble.rs
@@ -93,7 +93,7 @@ impl ContractEnsemble {
         &mut self, 
         address: impl Into<HumanAddr>, 
         coins: Vec<Coin>
-    ) -> StdResult<()> {
+    ) -> UsuallyOk {
         self.ctx.bank.current.remove_funds(&address.into(), coins)
     }
 

--- a/crates/fadroma/ensemble/mod.rs
+++ b/crates/fadroma/ensemble/mod.rs
@@ -17,6 +17,8 @@ mod storage;
 mod block;
 #[cfg(not(target_arch = "wasm32"))]
 mod response;
+#[cfg(not(target_arch = "wasm32"))]
+mod staking;
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests;

--- a/crates/fadroma/ensemble/querier.rs
+++ b/crates/fadroma/ensemble/querier.rs
@@ -70,7 +70,7 @@ impl Querier for EnsembleQuerier {
             },
             QueryRequest::Staking(query) => match query {
                 StakingQuery::AllDelegations { delegator } => {
-                    let delegations = ctx.delegations.all_delegations(delegator);
+                    let delegations = ctx.delegations.all_delegations(&delegator);
 
                     Ok(to_binary(&AllDelegationsResponse { delegations }))
                 },
@@ -80,12 +80,12 @@ impl Querier for EnsembleQuerier {
                     Ok(to_binary(&BondedDenomResponse { denom }))
                 },
                 StakingQuery::Delegation { delegator, validator } => {
-                    let delegation = ctx.delegations.delegation(delegator, validator);
+                    let delegation = ctx.delegations.delegation(&delegator, &validator);
 
-                    Ok(to_binary(&DelegationResponse { delegation }))
+                    Ok(to_binary(&delegation))
                 },
                 StakingQuery::UnbondingDelegations { delegator } => {
-                    let delegations = ctx.delegations.unbonding_delegations(delegator);
+                    let delegations = ctx.delegations.unbonding_delegations(&delegator);
 
                     Ok(to_binary(&UnbondingDelegationsResponse { delegations }))
                 },
@@ -93,6 +93,13 @@ impl Querier for EnsembleQuerier {
                     let validators = ctx.delegations.validators();
 
                     Ok(to_binary(&ValidatorsResponse { validators }))
+                },
+            },
+            QueryRequest::Dist(query) => match query {
+                DistQuery::Rewards { delegator } => {
+                    let rewards = ctx.delegations.rewards(&delegator);
+
+                    Ok(to_binary(&rewards))
                 },
             },
             _ => {

--- a/crates/fadroma/ensemble/querier.rs
+++ b/crates/fadroma/ensemble/querier.rs
@@ -68,7 +68,36 @@ impl Querier for EnsembleQuerier {
                     }))
                 }
             },
-            _ => Ok(self.base.query(&request)),
+            QueryRequest::Staking(query) => match query {
+                StakingQuery::AllDelegations { delegator } => {
+                    let delegations = ctx.delegations.all_delegations(delegator);
+
+                    Ok(to_binary(&AllDelegationsResponse { delegations }))
+                },
+                StakingQuery::BondedDenom {} => {
+                    let denom = ctx.delegations.bonded_denom();
+
+                    Ok(to_binary(&BondedDenomResponse { denom }))
+                },
+                StakingQuery::Delegation { delegator, validator } => {
+                    let delegation = ctx.delegations.delegation(delegator, validator);
+
+                    Ok(to_binary(&DelegationResponse { delegation }))
+                },
+                StakingQuery::UnbondingDelegations { delegator } => {
+                    let delegations = ctx.delegations.unbonding_delegations(delegator);
+
+                    Ok(to_binary(&UnbondingDelegationsResponse { delegations }))
+                },
+                StakingQuery::Validators {} => {
+                    let validators = ctx.delegations.validators();
+
+                    Ok(to_binary(&ValidatorsResponse { validators }))
+                },
+            },
+            _ => {
+                Ok(self.base.query(&request))
+            },
         }
     }
 }

--- a/crates/fadroma/ensemble/querier.rs
+++ b/crates/fadroma/ensemble/querier.rs
@@ -77,7 +77,7 @@ impl Querier for EnsembleQuerier {
                 StakingQuery::BondedDenom {} => {
                     let denom = ctx.delegations.bonded_denom();
 
-                    Ok(to_binary(&BondedDenomResponse { denom }))
+                    Ok(to_binary(&BondedDenomResponse { denom: denom.to_string() }))
                 },
                 StakingQuery::Delegation { delegator, validator } => {
                     let delegation = ctx.delegations.delegation(&delegator, &validator);
@@ -92,7 +92,7 @@ impl Querier for EnsembleQuerier {
                 StakingQuery::Validators {} => {
                     let validators = ctx.delegations.validators();
 
-                    Ok(to_binary(&ValidatorsResponse { validators }))
+                    Ok(to_binary(&ValidatorsResponse { validators: validators.to_vec() }))
                 },
             },
             QueryRequest::Dist(query) => match query {

--- a/crates/fadroma/ensemble/response.rs
+++ b/crates/fadroma/ensemble/response.rs
@@ -9,7 +9,8 @@ use crate::{
 pub enum Response {
     Instantiate(InstantiateResponse),
     Execute(ExecuteResponse),
-    Bank(BankResponse)
+    Bank(BankResponse),
+    Staking(StakingResponse),
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -49,6 +50,17 @@ pub struct BankResponse {
     /// The funds that were sent.
     pub coins: Vec<Coin>
 }
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct StakingResponse {
+    /// The address that delegated the funds.
+    pub sender: HumanAddr,
+    /// The address of the validator where the funds were sent.
+    pub validator: HumanAddr,
+    /// The funds that were sent.
+    pub amount: Coin,
+}
+
 
 pub struct Iter<'a> {
     responses: &'a [Response],
@@ -118,7 +130,8 @@ impl<'a> Iter<'a> {
         self.filter(move |x| match x {
             Response::Instantiate(resp) => resp.sender == sender,
             Response::Execute(resp) => resp.sender == sender,
-            Response::Bank(resp) => resp.sender == sender
+            Response::Bank(resp) => resp.sender == sender,
+            Response::Staking(resp) => resp.sender == sender,
         })
     }
 
@@ -136,7 +149,8 @@ impl<'a> Iter<'a> {
                 self.stack.extend(resp.sent.iter().rev()),
             Response::Instantiate(resp) =>
                 self.stack.extend(resp.sent.iter().rev()),
-            Response::Bank(_) => { }
+            Response::Bank(_) => { },
+            Response::Staking(_) => { },
         }
     }
 }

--- a/crates/fadroma/ensemble/response.rs
+++ b/crates/fadroma/ensemble/response.rs
@@ -61,7 +61,6 @@ pub struct StakingResponse {
     pub amount: Coin,
 }
 
-
 pub struct Iter<'a> {
     responses: &'a [Response],
     index: usize,

--- a/crates/fadroma/ensemble/response.rs
+++ b/crates/fadroma/ensemble/response.rs
@@ -5,6 +5,8 @@ use crate::{
     cosmwasm_std::{HumanAddr, Binary, InitResponse, HandleResponse, Coin}
 };
 
+use serde::{Serialize, Deserialize};
+
 #[derive(Clone, PartialEq, Debug)]
 pub enum Response {
     Instantiate(InstantiateResponse),
@@ -59,6 +61,21 @@ pub struct StakingResponse {
     pub validator: HumanAddr,
     /// The funds that were sent.
     pub amount: Coin,
+}
+
+// Copying struct from cosmwasm because ValidatorRewards is not currently visible, which 
+// is used in RewardsResponse
+/// Rewards response
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct RewardsResponse {
+    pub rewards: Vec<ValidatorRewards>,
+    pub total: Vec<Coin>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct ValidatorRewards {
+    pub validator_address: HumanAddr,
+    pub reward: Vec<Coin>,
 }
 
 pub struct Iter<'a> {

--- a/crates/fadroma/ensemble/staking.rs
+++ b/crates/fadroma/ensemble/staking.rs
@@ -1,0 +1,388 @@
+use std::collections::HashMap;
+
+use crate::prelude::*;
+use super::response::StakingResponse;
+
+#[derive(Clone, Default, Debug)]
+pub(crate) struct Unbonding {
+    start_time: u64,
+    amount: Coin,
+}
+
+#[derive(Clone, Default, Debug)]
+pub(crate) struct DelegationWithUnbonding {
+    delegator: HumanAddr,
+    validator: HumanAddr,
+    amount: Coin,
+    unbondings: Vec<Unbonding>,
+    can_redelegate: Coin,
+    accumulated_rewards: Coin,
+}
+
+pub(crate) type Delegator = HashMap<HumanAddr, DelegationWithUnbonding>;
+
+#[derive(Debug)]
+pub(crate) struct Delegations {
+    /// Denom for bonded currency
+    bonded_denom: String,
+    /// Time in seconds before undelegations are available
+
+    /// List of all valid validators
+    validators: Vec<Validator>,
+    /// Doubly hashed array of delegations for easy access
+    delegators: HashMap<HumanAddr, Delegator>,
+}
+
+impl DelegationWithUnbonding {
+    pub fn to_delegation(&self) -> Delegation {
+        Delegation {
+            delegator: self.delegator.clone(),
+            validator: self.validator.clone(),
+            amount: self.amount.clone(),
+        }
+    }
+
+    pub fn to_full_delegation(&self) -> FullDelegation {
+        FullDelegation {
+            delegator: self.delegator.clone(),
+            validator: self.validator.clone(),
+            amount: self.amount.clone(),
+            can_redelegate: self.can_redelegate.clone(),
+            accumulated_rewards: self.accumulated_rewards.clone(),
+        }
+    }
+}
+
+impl Delegations {
+    pub fn new<'a>(bonded_denom: String) -> Self {
+        Self {
+            bonded_denom,
+            validators: Default::default(),
+            delegators: Default::default(),
+        }
+    }
+
+    pub fn add_validator(&mut self, new_validator: Validator) {
+        self.validators.push(new_validator);
+    }
+
+    pub fn distribute_rewards(&mut self, amount: Uint128) {
+        for delegator in self.delegators.iter_mut() {
+            for delegation_pair in delegator.1 {
+                let delegation = delegation_pair.1;
+                let new_rewards = Coin {
+                    denom: self.bonded_denom.clone(),
+                    amount: delegation.accumulated_rewards.amount + amount,
+                };
+                delegation.accumulated_rewards = new_rewards;
+            }
+        }
+    }
+    
+    // Validator queries
+    pub fn bonded_denom(&self) -> String {
+        self.bonded_denom.clone()
+    }
+
+    pub fn all_delegations(&self, delegator: HumanAddr) -> Vec<Delegation> {
+        match self.delegators.get(&delegator) {
+            Some(delegations) => {
+                let mut return_delegations: Vec<Delegation> = vec![];
+                for delegation in delegations {
+                    return_delegations.push((*delegation.1).to_delegation());
+                }
+                return_delegations
+            }
+            None => vec![]
+        }
+    }
+
+    pub fn delegation(
+        &self, 
+        delegator: HumanAddr, 
+        validator: HumanAddr
+    ) -> Option<FullDelegation> {
+        match self.get_delegation(&delegator, &validator) {
+            Some(delegation) => Some(delegation.to_full_delegation()),
+            None => None,
+        }
+    }
+
+    pub fn validators(&self) -> Vec<Validator> {
+        self.validators.clone()
+    }
+
+    pub fn unbonding_delegations(&self, delegator: HumanAddr) -> Vec<Delegation> {
+        match self.delegators.get(&delegator) {
+            Some(delegations) => {
+                let mut return_delegations: Vec<Delegation> = vec![];
+                for delegation_pair in delegations {
+                    let delegation = delegation_pair.1;
+                    for unbonding in delegation.unbondings.clone() {
+                        let unbonding_delegation = Delegation {
+                            delegator: delegation.delegator.clone(),
+                            validator: delegation.validator.clone(),
+                            amount: unbonding.amount,
+                        };
+                        return_delegations.push(unbonding_delegation);
+                    }
+                }
+                return_delegations
+            },
+            None => vec![]
+        }
+    }
+
+    // Validator transaction messages 
+    pub fn delegate(
+        &mut self, 
+        delegator: HumanAddr, 
+        validator: HumanAddr, 
+        amount: Coin
+    ) -> StdResult<StakingResponse> {
+        if amount.denom != self.bonded_denom {
+            return Err(StdError::generic_err("Incorrect coin denom"));
+        }
+        if !self.validate_validator(&validator) {
+            return Err(StdError::not_found("Validator not found"));
+        }
+       
+        let mut new_delegation = DelegationWithUnbonding {
+            delegator: delegator.clone(),
+            validator: validator.clone(),
+            amount: amount.clone(),
+            unbondings: vec![],
+            can_redelegate: Coin {
+                denom: self.bonded_denom.clone(),
+                amount: Uint128::zero(),
+            },
+            accumulated_rewards: Coin {
+                denom: self.bonded_denom.clone(),
+                amount: Uint128::zero(),
+            },
+        };
+       
+        // Check if delegation pair exists, add amounts if so
+        match self.delegators.get_mut(&delegator) {
+            Some(cur_delegator) => {
+                match cur_delegator.get(&validator) {
+                    Some(ref old_deleg) => {
+                        let old_delegation = (*old_deleg).clone();
+                        new_delegation.amount = Coin {
+                            denom: self.bonded_denom.clone(),
+                            amount: old_delegation.amount.amount + amount.amount,
+                        };
+                        new_delegation.unbondings = old_delegation.unbondings;
+                        new_delegation.can_redelegate = old_delegation.can_redelegate;
+                        new_delegation.accumulated_rewards = old_delegation.accumulated_rewards;
+                    },
+                    None => { }
+                }
+            },
+            None => { }
+        };
+
+        self.insert_delegation(delegator.clone(), validator.clone(), new_delegation);
+
+        Ok(StakingResponse {
+            sender: delegator.clone(),
+            validator: validator.clone(),
+            amount: amount.clone(),
+        })
+    }
+
+    pub fn undelegate(
+        &mut self,
+        delegator: HumanAddr,
+        validator: HumanAddr,
+        amount: Coin
+    ) -> StdResult<StakingResponse> {
+        if amount.denom != self.bonded_denom {
+            return Err(StdError::generic_err("Incorrect coin denom"));
+        }
+
+        match self.get_delegation(&delegator, &validator) {
+            Some(delegation) => {
+                if amount.amount > delegation.amount.amount {
+                    return Err(StdError::generic_err("Insufficient funds"));
+                }
+
+                let new_unbonding = Unbonding {
+                    start_time: std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap().as_secs(),
+                    amount: Coin {
+                        denom: self.bonded_denom.clone(),
+                        amount: amount.amount,
+                    },
+                };
+
+                let mut new_delegation = DelegationWithUnbonding {
+                    delegator: delegator.clone(),
+                    validator: validator.clone(),
+                    amount: Coin {
+                        denom: self.bonded_denom.clone(),
+                        amount: (delegation.amount.amount - amount.amount).unwrap(),
+                    },
+                    unbondings: delegation.unbondings,
+                    can_redelegate: delegation.can_redelegate,
+                    accumulated_rewards: delegation.accumulated_rewards,
+                };
+                new_delegation.unbondings.push(new_unbonding);
+
+                self.insert_delegation(delegator.clone(), validator.clone(), new_delegation);
+                
+                Ok(StakingResponse {
+                    sender: delegator.clone(),
+                    validator: validator.clone(),
+                    amount: amount.clone(),
+                })
+            },
+            None => Err(StdError::not_found("Delegation not found"))
+        }
+    }
+
+    pub fn withdraw(
+        &mut self,
+        delegator: HumanAddr,
+        validator: HumanAddr,
+    ) -> StdResult<StakingResponse> { 
+        match self.get_delegation(&delegator, &validator) {
+            Some(delegation) => {
+                let new_delegation = DelegationWithUnbonding {
+                    delegator: delegator.clone(),
+                    validator: validator.clone(),
+                    amount: delegation.amount,
+                    unbondings: delegation.unbondings,
+                    can_redelegate: delegation.can_redelegate,
+                    accumulated_rewards: Coin {
+                        denom: self.bonded_denom.clone(),
+                        amount: Uint128::zero(),
+                    },
+                };
+                self.insert_delegation(delegator.clone(), validator.clone(), new_delegation);
+                
+                Ok(StakingResponse {
+                    sender: delegator.clone(),
+                    validator: validator.clone(),
+                    amount: delegation.accumulated_rewards.clone(),
+                })
+            },
+            None => Err(StdError::not_found("Delegation not found"))
+        }
+    }
+
+    pub fn redelegate(
+        &mut self,
+        delegator: HumanAddr,
+        src_validator: HumanAddr,
+        dst_validator: HumanAddr,
+        amount: Coin
+        ) -> StdResult<StakingResponse> {
+        if amount.denom != self.bonded_denom {
+            return Err(StdError::generic_err("Incorrect coin denom"));
+        }
+
+        match self.get_delegation(&delegator, &src_validator) {
+            Some(delegation) => {
+                if amount.amount > delegation.amount.amount {
+                    return Err(StdError::generic_err("Insufficient funds"));
+                }
+
+                if !self.validate_validator(&dst_validator) {
+                    return Err(StdError::not_found("Destination validator does not exist"));
+                }
+
+                let new_src_delegation = DelegationWithUnbonding {
+                    delegator: delegator.clone(),
+                    validator: src_validator.clone(),
+                    amount: Coin {
+                        denom: self.bonded_denom.clone(),
+                        amount: (delegation.amount.amount - amount.amount).unwrap(),
+                    },
+                    unbondings: delegation.unbondings,
+                    can_redelegate: delegation.can_redelegate,
+                    accumulated_rewards: delegation.accumulated_rewards,
+                };
+                self.insert_delegation(
+                    delegator.clone(), 
+                    src_validator.clone(), 
+                    new_src_delegation.clone()
+                );
+
+                let new_dst_delegation = DelegationWithUnbonding {
+                    delegator: delegator.clone(),
+                    validator: dst_validator.clone(),
+                    amount: Coin {
+                        denom: self.bonded_denom.clone(),
+                        amount: delegation.amount.amount + amount.amount,
+                    },
+                    unbondings: vec![],
+                    can_redelegate: Coin {
+                        denom: self.bonded_denom.clone(),
+                        amount: Uint128::zero(),
+                    },
+                    accumulated_rewards: Coin {
+                        denom: self.bonded_denom.clone(),
+                        amount: Uint128::zero(),
+                    },
+                };
+                self.insert_delegation(delegator.clone(), dst_validator.clone(), new_dst_delegation);
+
+                Ok(StakingResponse {
+                    sender: delegator.clone(),
+                    validator: dst_validator.clone(),
+                    amount: amount.clone(),
+                })
+            },
+            None => Err(StdError::not_found("Delegation not found"))
+        }
+
+    }
+    
+    // Helper methods
+    fn get_delegation(
+        &self, 
+        delegator: &HumanAddr, 
+        validator: &HumanAddr,
+    ) -> Option<DelegationWithUnbonding> {
+        match self.delegators.get(&delegator) {
+            Some(cur_delegator) => {
+                match cur_delegator.get(&validator).clone() {
+                    Some(ref delegation) => Some((*delegation).clone()),
+                    _ => None,
+                }
+            },
+            _ => None,
+        }
+    }
+
+    fn insert_delegation(
+        &mut self,
+        delegator: HumanAddr,
+        validator: HumanAddr,
+        new_delegation: DelegationWithUnbonding
+    ) -> Option<DelegationWithUnbonding> {
+        match self.delegators.get_mut(&delegator) {
+            Some(cur_delegator) => {
+                cur_delegator.insert(validator, new_delegation)
+            },
+            None => {
+                let mut new_delegator: Delegator = Default::default();
+                new_delegator.insert(validator, new_delegation);
+                self.delegators.insert(delegator, new_delegator);
+                None
+            },
+        }
+    }
+
+    fn validate_validator(&self, validator: &HumanAddr) -> bool {
+        for real_validator in self.validators.clone() {
+            if real_validator.address == validator.into() {
+                return true;
+            }
+        }
+        false
+    }
+
+}

--- a/crates/fadroma/ensemble/staking.rs
+++ b/crates/fadroma/ensemble/staking.rs
@@ -148,7 +148,9 @@ impl Delegations {
                     let delegation = delegation_pair.1;
                     total += delegation.accumulated_rewards.amount.u128();
                 }
-
+                
+                // Cannot return any actual ValidatorRewards structs because the struct is
+                // private at the moment.
                 RewardsResponse {
                     rewards: vec![],
                     total: vec![Coin::new(total, &self.bonded_denom)],

--- a/crates/fadroma/ensemble/staking.rs
+++ b/crates/fadroma/ensemble/staking.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::prelude::*;
-use super::response::StakingResponse;
+use super::response::{StakingResponse, RewardsResponse, ValidatorRewards};
 
 #[derive(Clone, Debug)]
 pub(crate) struct DelegationWithUnbonding {
@@ -146,21 +146,28 @@ impl Delegations {
         match self.delegators.get(delegator) {
             Some(delegations) => {
                 let mut total = 0u128;
+                let mut rewards = vec![];
                 for delegation_pair in delegations {
                     let delegation = delegation_pair.1;
                     total += delegation.accumulated_rewards.amount.u128();
+                    rewards.push(ValidatorRewards{
+                        validator_address: delegation.validator.clone(),
+                        reward: vec![delegation.accumulated_rewards.clone()],
+                    });
                 }
                 
                 // Cannot return any actual ValidatorRewards structs because the struct is
                 // private at the moment.
                 RewardsResponse {
-                    rewards: vec![],
+                    rewards,
                     total: vec![Coin::new(total, &self.bonded_denom)],
                 }
             },
-            None => RewardsResponse {
-                rewards: vec![],
-                total: vec![],
+            None => {
+                RewardsResponse {
+                    rewards: vec![],
+                    total: vec![],
+                }
             },
         }
     }

--- a/crates/fadroma/ensemble/tests.rs
+++ b/crates/fadroma/ensemble/tests.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use serde::{Deserialize, Serialize};
 use super::{ContractEnsemble, ContractHarness, MockDeps, MockEnv};
+use super::response::{RewardsResponse, ValidatorRewards};
 
 const SEND_AMOUNT: u128 = 100;
 const SEND_DENOM: &str = "uscrt";
@@ -914,10 +915,19 @@ fn staking() {
         vec![Coin::new(50u128, "uscrt")],
     );
 
+    let mut rewards_result = ensemble.ctx.delegations.rewards(&addr1);
+    rewards_result.rewards.sort_by(|a, b| a.validator_address.to_string().cmp(&b.validator_address.to_string()));
     assert_eq!(
-        ensemble.ctx.delegations.rewards(&addr1),
+        rewards_result,
         RewardsResponse {
-            rewards: vec![],
+            rewards: vec![ValidatorRewards {
+                validator_address: val_addr_1.clone(),
+                reward: vec![Coin::new(0u128, "uscrt")],
+            },
+            ValidatorRewards {
+                validator_address: val_addr_2.clone(),
+                reward: vec![Coin::new(50u128, "uscrt")],
+            }],
             total: vec![Coin::new(50u128, "uscrt")],
         },
     );


### PR DESCRIPTION
Basic staking and validating functionality added to ensemble for testing use

Features:
 - Tracking delegations for multiple validators
 - delegations, validators, unbondings, and rewards queries
 - delegate, undelegate, withdraw and redelegate messages
 - Manual 'add rewards' function to distribute rewards to all individual delegations
 - Manual 'fast forward' function to simulate waiting during testing