### PR TITLE
Refactor the contract harness macro

### DIFF
--- a/CHANGELOG-RUST.md
+++ b/CHANGELOG-RUST.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+ - BREAKING ⚠️: Renamed the `impl_contract_harness!` macro to `contract_harness!`. It now also uses the same
+ syntax as the `entrypoint!` macro and allows to optionally supply a reply entry point. ([#168](https://github.com/hackbg/fadroma/pull/168))
+
 ## [0.8.6] - 2023-04-28
 
 ### Changed

--- a/crates/fadroma/ensemble/mod.rs
+++ b/crates/fadroma/ensemble/mod.rs
@@ -26,61 +26,167 @@ pub use response::*;
 pub use error::*;
 pub use anyhow;
 
-/// Generate a struct and implement [`ContractHarness`] for the given contract module.
+/// Generate a struct and implement [`ContractHarness`] for the given struct identifier,
+/// using the provided entry point functions.
+/// 
+/// Supports `init`, `execute` and `query` **or**
+/// `init`, `execute`, `query` and `reply`.
+/// 
+/// # Examples
+/// 
+/// ```
+/// # #[macro_use] extern crate fadroma;
+/// # use fadroma::cosmwasm_std::{Deps, DepsMut, Env, MessageInfo, StdResult, Response, Binary, to_binary};
+/// # #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+/// # pub struct InitMsg;
+/// # #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+/// # pub struct ExecuteMsg;
+/// # #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+/// # pub struct QueryMsg;
+/// pub fn instantiate(
+///     _deps: DepsMut,
+///     _env: Env,
+///     _info: MessageInfo,
+///     _msg: InitMsg
+/// ) -> StdResult<Response> {
+///     Ok(Response::default())
+/// }
+///
+/// pub fn execute(
+///     _deps: DepsMut,
+///     _env: Env,
+///     _info: MessageInfo,
+///     _msg: ExecuteMsg
+/// ) -> StdResult<Response> {
+///     Ok(Response::default())
+/// }
+///
+/// pub fn query(
+///     _deps: Deps,
+///     _env: Env,
+///     _msg: QueryMsg
+/// ) -> StdResult<Binary> {
+///     to_binary(&true)
+/// }
+/// 
+/// contract_harness! {
+///     pub NameOfStruct,
+///     init: instantiate,
+///     execute: execute,
+///     query: query
+/// }
+/// ```
 #[macro_export]
-macro_rules! impl_contract_harness {
-    ($visibility:vis $name:ident, $module:tt) => {
+macro_rules! contract_harness {
+    (@init $init:path) => {
+        fn instantiate(
+            &self,
+            deps: $crate::cosmwasm_std::DepsMut,
+            env: $crate::cosmwasm_std::Env,
+            info: $crate::cosmwasm_std::MessageInfo,
+            msg: $crate::cosmwasm_std::Binary
+        ) -> $crate::ensemble::AnyResult<$crate::cosmwasm_std::Response> {
+            let result = $init(
+                deps,
+                env,
+                info,
+                $crate::cosmwasm_std::from_binary(&msg)?
+            )?;
+
+            Ok(result)
+        }
+    };
+
+    (@execute $execute:path) => {
+        fn execute(
+            &self,
+            deps: $crate::cosmwasm_std::DepsMut,
+            env: $crate::cosmwasm_std::Env,
+            info: $crate::cosmwasm_std::MessageInfo,
+            msg: $crate::cosmwasm_std::Binary
+        ) -> $crate::ensemble::AnyResult<$crate::cosmwasm_std::Response> {
+            let result = $execute(
+                deps,
+                env,
+                info,
+                $crate::cosmwasm_std::from_binary(&msg)?
+            )?;
+
+            Ok(result)
+        }
+    };
+
+    (@query $query:path) => {
+        fn query(
+            &self,
+            deps: $crate::cosmwasm_std::Deps,
+            env: $crate::cosmwasm_std::Env,
+            msg: $crate::cosmwasm_std::Binary
+        ) -> $crate::ensemble::AnyResult<$crate::cosmwasm_std::Binary> {
+            let result = $query(
+                deps,
+                env,
+                $crate::cosmwasm_std::from_binary(&msg)?
+            )?;
+
+            Ok(result)
+        }
+    };
+
+    (@reply $reply:path) => {
+        fn reply(
+            &self,
+            deps: $crate::cosmwasm_std::DepsMut,
+            env: $crate::cosmwasm_std::Env,
+            reply: $crate::cosmwasm_std::Reply
+        ) -> $crate::ensemble::AnyResult<$crate::cosmwasm_std::Response> {
+            let result = $reply(
+                deps,
+                env,
+                reply
+            )?;
+
+            Ok(result)
+        }
+    };
+
+    (@trait_impl $visibility:vis $name:ident, $($contents:tt)*) => {
         $visibility struct $name;
 
         impl $crate::ensemble::ContractHarness for $name {
-            fn instantiate(
-                &self,
-                deps: $crate::cosmwasm_std::DepsMut,
-                env: $crate::cosmwasm_std::Env,
-                info: $crate::cosmwasm_std::MessageInfo,
-                msg: $crate::cosmwasm_std::Binary
-            ) -> $crate::ensemble::AnyResult<$crate::cosmwasm_std::Response> {
-                let result = $module::instantiate(
-                    deps,
-                    env,
-                    info,
-                    $crate::cosmwasm_std::from_binary(&msg)?
-                )?;
+            $($contents)*
+        }
+    };
 
-                Ok(result)
-            }
+    (
+        $visibility:vis $name:ident,
+        init: $init:path,
+        execute: $execute:path,
+        query: $query:path,
+        reply: $reply:path
+    ) => {
+        $crate::contract_harness! {
+            @trait_impl
+            $visibility $name,
+            $crate::contract_harness!(@init $init);
+            $crate::contract_harness!(@execute $execute);
+            $crate::contract_harness!(@query $query);
+            $crate::contract_harness!(@reply $reply);
+        }
+    };
 
-            fn execute(
-                &self,
-                deps: $crate::cosmwasm_std::DepsMut,
-                env: $crate::cosmwasm_std::Env,
-                info: $crate::cosmwasm_std::MessageInfo,
-                msg: $crate::cosmwasm_std::Binary
-            ) -> $crate::ensemble::AnyResult<$crate::cosmwasm_std::Response> {
-                let result = $module::execute(
-                    deps,
-                    env,
-                    info,
-                    $crate::cosmwasm_std::from_binary(&msg)?
-                )?;
-
-                Ok(result)
-            }
-
-            fn query(
-                &self,
-                deps: $crate::cosmwasm_std::Deps,
-                env: $crate::cosmwasm_std::Env,
-                msg: $crate::cosmwasm_std::Binary
-            ) -> $crate::ensemble::AnyResult<$crate::cosmwasm_std::Binary> {
-                let result = $module::query(
-                    deps,
-                    env,
-                    $crate::cosmwasm_std::from_binary(&msg)?
-                )?;
-
-                Ok(result)
-            }
+    (
+        $visibility:vis $name:ident,
+        init: $init:path,
+        execute: $execute:path,
+        query: $query:path
+    ) => {
+        $crate::contract_harness! {
+            @trait_impl
+            $visibility $name,
+            $crate::contract_harness!(@init $init);
+            $crate::contract_harness!(@execute $execute);
+            $crate::contract_harness!(@query $query);
         }
     };
 }

--- a/crates/fadroma/lib.rs
+++ b/crates/fadroma/lib.rs
@@ -118,28 +118,28 @@ pub mod prelude {
 /// ```
 #[macro_export]
 macro_rules! entrypoint {
-    (@init $init:path) => {
+    (@init $init:ident) => {
         #[no_mangle]
         extern "C" fn instantiate(env_ptr: u32, info_ptr: u32, msg_ptr: u32) -> u32 {
             $crate::cosmwasm_std::do_instantiate(&super::$init, env_ptr, info_ptr, msg_ptr)
         }
     };
 
-    (@execute $execute:path) => {
+    (@execute $execute:ident) => {
         #[no_mangle]
         extern "C" fn execute(env_ptr: u32, info_ptr: u32, msg_ptr: u32) -> u32 {
             $crate::cosmwasm_std::do_execute(&super::$execute, env_ptr, info_ptr, msg_ptr)
         }
     };
 
-    (@query $query:path) => {
+    (@query $query:ident) => {
         #[no_mangle]
         extern "C" fn query(env_ptr: u32, msg_ptr: u32) -> u32 {
             $crate::cosmwasm_std::do_query(&super::$query, env_ptr, msg_ptr)
         }
     };
 
-    (@reply $reply:path) => {
+    (@reply $reply:ident) => {
         #[no_mangle]
         extern "C" fn reply(env_ptr: u32, msg_ptr: u32) -> u32 {
             $crate::cosmwasm_std::do_reply(&super::$reply, env_ptr, msg_ptr)
@@ -153,7 +153,7 @@ macro_rules! entrypoint {
         }
     };
 
-    (init: $init:path, execute: $execute:path, query: $query:path, reply: $reply:path) => {
+    (init: $init:ident, execute: $execute:ident, query: $query:ident, reply: $reply:ident) => {
         $crate::entrypoint! {
             @wasm_mod
             $crate::entrypoint!(@init $init);
@@ -163,7 +163,7 @@ macro_rules! entrypoint {
         }
     };
 
-    (init: $init:path, execute: $execute:path, query: $query:path) => {
+    (init: $init:ident, execute: $execute:ident, query: $query:ident) => {
         $crate::entrypoint! {
             @wasm_mod
             $crate::entrypoint!(@init $init);

--- a/examples/admin/src/lib.rs
+++ b/examples/admin/src/lib.rs
@@ -147,7 +147,12 @@ mod tests {
         ensemble::{ContractEnsemble, MockEnv}
     };
 
-    fadroma::impl_contract_harness!(CounterWithAdminTest, super);
+    fadroma::contract_harness!(
+        CounterWithAdminTest,
+        init: super::instantiate,
+        execute: super::execute,
+        query: super::query
+    );
 
     #[test]
     fn test_admin() {

--- a/examples/derive-contract-components/src/lib.rs
+++ b/examples/derive-contract-components/src/lib.rs
@@ -105,7 +105,12 @@ mod tests {
     use super::contract::{self, InstantiateMsg, ExecuteMsg, QueryMsg};
 
     const ADMIN: &str = "admin";
-    fadroma::impl_contract_harness!(SecretNumberTest, contract);
+    fadroma::contract_harness!(
+        SecretNumberTest,
+        init: contract::instantiate,
+        execute: contract::execute,
+        query: contract::query
+    );
 
     struct TestSuite {
         ensemble: ContractEnsemble,

--- a/examples/ensemble/src/lib.rs
+++ b/examples/ensemble/src/lib.rs
@@ -48,7 +48,12 @@ impl ContractHarness for Oracle {
     }
 }
 
-fadroma::impl_contract_harness!(TestContract, counter);
+fadroma::contract_harness!(
+    TestContract,
+    init: counter::instantiate,
+    execute: counter::execute,
+    query: counter::query
+);
 
 #[test]
 fn test_contracts() {

--- a/examples/killswitch/src/lib.rs
+++ b/examples/killswitch/src/lib.rs
@@ -132,7 +132,12 @@ mod tests {
         ensemble::{ContractEnsemble, MockEnv}
     };
 
-    fadroma::impl_contract_harness!(KillswitchTest, super);
+    fadroma::contract_harness!(
+        KillswitchTest,
+        init: super::instantiate,
+        execute: super::execute,
+        query: super::query
+    );
 
     #[test]
     fn test_killswitch() {


### PR DESCRIPTION
Renamed the `impl_contract_harness!` macro to `contract_harness!` and the syntax is now the same as the `entrypoint!` macro. This now allows us to implement the reply entry point as well. By not requiring a single module, we are also more flexible.