### PR TITLE
Add Address and MaybeAddress traits.

### DIFF
--- a/CHANGELOG-RUST.md
+++ b/CHANGELOG-RUST.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+ - BREAKING ⚠️: Introduced the `Address` and `MaybeAddress` marker traits to constrain the
+ possible types for generic arguments as well as making it clear that an address is expected.
+ ([#177](https://github.com/hackbg/fadroma/pull/177))
+
 ## [0.8.7] - 2023-05-12
 
 ### Changed

--- a/crates/fadroma-derive-canonize/src/generic.rs
+++ b/crates/fadroma-derive-canonize/src/generic.rs
@@ -8,7 +8,7 @@ pub fn generate(strukt: ItemStruct) -> proc_macro::TokenStream {
     if strukt.generics.params.len() > 1 {
         let err = syn::Error::new(
             Span::call_site(),
-            "Structs with multiple generic arguments currently not supported."
+            "Structs with multiple generic arguments are currently not supported."
         ).into_compile_error();
 
         return proc_macro::TokenStream::from(quote!(#err))

--- a/crates/fadroma-derive-canonize/src/generic_enum.rs
+++ b/crates/fadroma-derive-canonize/src/generic_enum.rs
@@ -7,7 +7,7 @@ pub fn generate(mut input: ItemEnum) -> proc_macro::TokenStream {
     if input.generics.params.len() > 1 {
         let err = syn::Error::new(
             Span::call_site(),
-            "Enums with multiple generic arguments current not supported.",
+            "Enums with multiple generic arguments are currently not supported.",
         )
         .into_compile_error();
 

--- a/crates/fadroma/core/callback.rs
+++ b/crates/fadroma/core/callback.rs
@@ -36,7 +36,18 @@ impl Callback<String> {
 impl Into<CosmosMsg> for Callback<Addr> {
     fn into(self) -> CosmosMsg {
         CosmosMsg::Wasm(WasmMsg::Execute {
-            contract_addr: self.contract.address.to_string(),
+            contract_addr: self.contract.address.into_string(),
+            code_hash: self.contract.code_hash,
+            msg: self.msg,
+            funds: vec![]
+        })
+    }
+}
+
+impl Into<CosmosMsg> for Callback<String> {
+    fn into(self) -> CosmosMsg {
+        CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: self.contract.address,
             code_hash: self.contract.code_hash,
             msg: self.msg,
             funds: vec![]

--- a/crates/fadroma/core/callback.rs
+++ b/crates/fadroma/core/callback.rs
@@ -4,7 +4,10 @@ use crate::{
     cosmwasm_std::{self, StdResult, Api, Addr, Binary, CosmosMsg, WasmMsg},
     schemars::{self, JsonSchema}
 };
-use super::link::ContractLink;
+use super::{
+    link::ContractLink,
+    addr::MaybeAddress
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +16,7 @@ use serde::{Deserialize, Serialize};
 /// didn't exist yet. However, it is still useful when you want to
 /// be able to reply with arbitrary messages.
 #[derive(Serialize, Deserialize, Canonize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct Callback<A> {
+pub struct Callback<A: MaybeAddress> {
     /// The message to call.
     pub msg: Binary,
     /// Info about the contract requesting the callback.

--- a/crates/fadroma/core/link.rs
+++ b/crates/fadroma/core/link.rs
@@ -74,6 +74,18 @@ impl ContractLink<String> {
     }
 }
 
+impl ContractLink<Addr> {
+    #[inline]
+    pub fn execute(self, msg: &impl Serialize, funds: Vec<Coin>) -> StdResult<WasmMsg> {
+        Ok(WasmMsg::Execute {
+            contract_addr: self.address.into_string(),
+            code_hash: self.code_hash,
+            msg: to_binary(msg)?,
+            funds
+        })
+    }
+}
+
 // Disregard code hash because it is case insensitive.
 // Converting to the same case first and the comparing is unnecessary
 // as providing the wrong code hash when calling a contract will result

--- a/crates/fadroma/core/link.rs
+++ b/crates/fadroma/core/link.rs
@@ -1,12 +1,13 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     self as fadroma,
     cosmwasm_std::{self, StdResult, Addr, Env, Api, WasmMsg, to_binary, Coin},
     impl_canonize_default,
     prelude::{Canonize, FadromaSerialize, FadromaDeserialize},
-    schemars::{self, JsonSchema},
+    schemars::{self, JsonSchema}
 };
-
-use serde::{Deserialize, Serialize};
+use super::addr::MaybeAddress;
 
 /// Info needed to instantiate a contract.
 #[derive(Serialize, Deserialize, FadromaSerialize, FadromaDeserialize, JsonSchema, Clone, Debug)]
@@ -48,7 +49,7 @@ impl ContractCode {
 
 /// Info needed to talk to a contract instance.
 #[derive(Default, Serialize, Canonize, Deserialize, FadromaSerialize, FadromaDeserialize, JsonSchema, Clone, Debug)]
-pub struct ContractLink<A> {
+pub struct ContractLink<A: MaybeAddress> {
     pub address: A,
     pub code_hash: String
 }
@@ -77,7 +78,7 @@ impl ContractLink<String> {
 // Converting to the same case first and the comparing is unnecessary
 // as providing the wrong code hash when calling a contract will result
 // in an error regardless and we have no way of checking that here.
-impl<A: PartialEq> PartialEq for ContractLink<A> {
+impl<A: MaybeAddress + PartialEq> PartialEq for ContractLink<A> {
     fn eq(&self, other: &Self) -> bool {
         self.address == other.address
     }
@@ -87,7 +88,7 @@ impl From<&Env> for ContractLink<Addr> {
     fn from(env: &Env) -> ContractLink<Addr> {
         ContractLink {
             address: env.contract.address.clone(),
-            code_hash: env.contract.code_hash.clone(),
+            code_hash: env.contract.code_hash.clone()
         }
     }
 }

--- a/crates/fadroma/core/mod.rs
+++ b/crates/fadroma/core/mod.rs
@@ -3,6 +3,10 @@ mod link;
 mod callback;
 
 pub use fadroma_derive_canonize::Canonize;
-pub use addr::{Humanize, Canonize};
+pub use addr::{Humanize, Canonize, MaybeAddress, Address};
 pub use link::*;
 pub use callback::*;
+
+pub(crate) mod sealed {
+    pub trait Sealed { }
+}

--- a/crates/fadroma/killswitch/mod.rs
+++ b/crates/fadroma/killswitch/mod.rs
@@ -19,7 +19,7 @@ pub const STORE: SingleItem<ContractStatus<CanonicalAddr>, KillswitchNs> = Singl
 
 /// Possible states of a contract.
 #[derive(Serialize, Deserialize, Canonize, FadromaSerialize, FadromaDeserialize, JsonSchema, PartialEq, Debug, Clone)]
-pub enum ContractStatus<A> {
+pub enum ContractStatus<A: Address> {
     /// Live
     Operational,
     /// Temporarily disabled
@@ -139,7 +139,7 @@ pub fn set_status(
     STORE.canonize_and_save(deps, status)
 }
 
-impl<A> Default for ContractStatus<A> {
+impl<A: Address> Default for ContractStatus<A> {
     fn default() -> Self {
         Self::Operational
     }

--- a/crates/fadroma/scrt/snip20/contract/state.rs
+++ b/crates/fadroma/scrt/snip20/contract/state.rs
@@ -10,7 +10,8 @@ use crate::{
     cosmwasm_std::{self, BlockInfo, CanonicalAddr, StdResult, Storage, Uint128, Deps},
     prelude::{
         ViewingKey, ViewingKeyHashed, SingleItem, ItemSpace, TypedKey,
-        TypedKey2, FadromaSerialize, FadromaDeserialize, Canonize, Humanize
+        TypedKey2, FadromaSerialize, FadromaDeserialize, Canonize, Humanize,
+        Address
     },
     impl_canonize_default
 };
@@ -84,7 +85,7 @@ pub struct Allowance {
 }
 
 #[derive(FadromaSerialize, FadromaDeserialize, JsonSchema, Canonize, Debug)]
-struct AllowanceEntry<A> {
+struct AllowanceEntry<A: Address> {
     spender: A,
     allowance: Allowance
 }

--- a/examples/factory/src/lib.rs
+++ b/examples/factory/src/lib.rs
@@ -22,8 +22,8 @@ pub mod factory {
 
     #[derive(Serialize, Deserialize, FadromaSerialize, FadromaDeserialize, Canonize, Debug)]
     #[serde(rename_all = "snake_case")]
-    pub struct Entry<A> {
-        pub link: ContractLink<A>,
+    pub struct Entry<A: Address> {
+        pub link: ContractLink<A>
     }
 
     impl Contract {


### PR DESCRIPTION
These are sealed traits that allow us to constrain the parameters on types that are supposed to be generic over addresses (i.e `Addr` and `CanonicalAddr`) or strings that may contain addresses. They also help with readability.

I also tried to make the `Canonize` derive macro to work only with generic types and explicitly denote which types to canonize by constraining them with those traits, but that would make it less flexible and would not be that straightforward and could also lead to unexpected behaviour by forgetting to constraint set the generic parameter. So that idea was scrapped.