### PR TITLE
Remove secretjs override

### DIFF
--- a/connect/cw/package.json
+++ b/connect/cw/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@fadroma/cw",
+  "version": "0.0.0",
+  "type":    "module",
+  "main":    "cw.ts",
+  "files": [ "*.ts" ],
+  "description": "Fadroma support for CosmWasm-based platforms other than Secret Network.",
+  "dependencies": {
+    "@hackbg/conf": "^2",
+    "@ungap/structured-clone": "^1.0.1",
+    "@cosmjs/stargate": "^0.30.1"
+  },
+  "peerDependencies": {
+    "@fadroma/agent": "workspace:1.0.0"
+  },
+  "devDependencies": {
+    "@types/ungap__structured-clone": "^0.3.0",
+    "@hackbg/ensuite": "^1.0.2"
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "ubik":  "npm run check && npm run cov && ubik",
+    "test":  "cd ../.. && ensuite spec/Scrt.spec.ts.md",
+    "cov":   "cd ../.. && ensuite-cov -r text -r lcov -- spec/Scrt.spec.ts.md"
+  }
+}
+


### PR DESCRIPTION
There's currently an elaborate hack for passing a custom SecretJS module instance to `@fadroma/scrt` to allow user-initiated upgrade of versions. This is a legacy escape hatch from around the SecretJS 1.2 era, and with `secretjs` being moved to peer dependencies as per #180, it becomes completely unnecessary.

However, it is still part of the public API of `@fadroma/scrt`, which is reexported all the way to `@hackbg/fadroma` by way of `@fadroma/connect`. Therefore removing it would be a breaking change and cause a major bump. So let's queue it up for the time being.