### PR TITLE
@fadroma/cw: @cosmjs/stargate support for Fadroma Agent

### DIFF
--- a/connect/cw/cw.ts
+++ b/connect/cw/cw.ts
@@ -1,0 +1,86 @@
+import { Config } from '@hackbg/conf'
+import { Chain, Agent, Bundle, Fee, Console, Error, bold, Mocknet } from '@fadroma/agent'
+import type { AgentClass, AgentFees, BundleClass, Uint128 } from '@fadroma/agent'
+
+class CosmosConfig extends Config {
+  /** The mainnet chain ID. */
+  static defaultMainnetChainId: string = ''
+  /** The mainnet URL. */
+  static defaultMainnetUrl:     string = ''
+  /** The testnet chain ID. */
+  static defaultTestnetChainId: string = ''
+  /** The testnet URL. */
+  static defaultTestnetUrl:     string = ''
+}
+
+class CosmosError extends Error {}
+
+class CosmosConsole extends Console {}
+
+class CosmosChain extends Chain {
+  log = new CosmosConsole('Cosmos')
+
+  static defaultDenom = 'uatom'
+  defaultDenom = CosmosChain.defaultDenom
+
+  static Agent: AgentClass<CosmosAgent> = CosmosChain.Agent
+  Agent: AgentClass<CosmosAgent> = CosmosChain.Agent
+
+  /** @returns a fresh instance of the anonymous read-only API client. */
+  async getApi (options: any = {}): Promise<any> {}
+
+  /** @returns Fee in uatom */
+  static gas = (amount: Uint128|number) => new Fee(amount, this.defaultDenom)
+  /** Connect to the Secret Network Mainnet. */
+  static mainnet = (options: Partial<CosmosChain> = {}): CosmosChain => super.mainnet({
+    id:  CosmosConfig.defaultMainnetChainId,
+    url: CosmosConfig.defaultMainnetUrl,
+    ...options||{},
+  }) as CosmosChain
+  /** Connect to the Secret Network Testnet. */
+  static testnet = (options: Partial<CosmosChain> = {}): CosmosChain => super.testnet({
+    id:  CosmosConfig.defaultTestnetChainId,
+    url: CosmosConfig.defaultTestnetUrl,
+    ...options||{},
+  }) as CosmosChain
+  /** Connect to a Secret Network devnet. */
+  static devnet = (options: Partial<CosmosChain> = {}): CosmosChain => super.devnet({
+    ...options||{},
+  }) as CosmosChain
+  /** Create to a Secret Network mocknet. */
+  static mocknet = (options: Partial<Mocknet.Chain> = {}): Mocknet.Chain => super.mocknet({
+    id: 'scrt-mocknet',
+    ...options||{}
+  })
+  /** Set permissive fees by default. */
+  static defaultFees: AgentFees = {
+    upload: this.gas(2000000),
+    init:   this.gas(2000000),
+    exec:   this.gas(1000000),
+    send:   this.gas(1000000),
+  }
+}
+
+class CosmosAgent extends Agent {
+  log = new CosmosConsole('CosmosAgent')
+  declare chain: CosmosChain
+  Bundle: BundleClass<CosmosBundle> = CosmosBundle
+  fees = CosmosChain.defaultFees
+
+  get ready (): Promise<this> {
+    return Promise.resolve(this)
+  }
+}
+
+class CosmosBundle extends Bundle {}
+
+Object.assign(CosmosChain, { Agent: Object.assign(CosmosAgent, { Bundle: CosmosBundle }) })
+
+export {
+  CosmosConfig  as Config,
+  CosmosError   as Error,
+  CosmosConsole as Console,
+  CosmosChain   as Chain,
+  CosmosBundle  as Bundle,
+  CosmosAgent   as Agent
+}

--- a/connect/cw/cw.ts
+++ b/connect/cw/cw.ts
@@ -49,7 +49,7 @@ class CosmosChain extends Chain {
   }) as CosmosChain
   /** Create to a Secret Network mocknet. */
   static mocknet = (options: Partial<Mocknet.Chain> = {}): Mocknet.Chain => super.mocknet({
-    id: 'scrt-mocknet',
+    id: 'cw-mocknet',
     ...options||{}
   })
   /** Set permissive fees by default. */

--- a/connect/cw/package.json
+++ b/connect/cw/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@fadroma/cw",
+  "version": "0.0.0",
+  "type":    "module",
+  "main":    "cw.ts",
+  "files": [ "*.ts" ],
+  "description": "Fadroma support for CosmWasm-based platforms other than Secret Network.",
+  "dependencies": {
+    "@hackbg/conf": "^2",
+    "@ungap/structured-clone": "^1.0.1"
+  },
+  "peerDependencies": {
+    "@fadroma/agent": "workspace:1.0.0",
+    "@cosmjs/stargate": "^0.30.1"
+  },
+  "devDependencies": {
+    "@types/ungap__structured-clone": "^0.3.0",
+    "@hackbg/ensuite": "^1.0.2"
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "ubik":  "npm run check && npm run cov && ubik",
+    "test":  "cd ../.. && ensuite spec/Scrt.spec.ts.md",
+    "cov":   "cd ../.. && ensuite-cov -r text -r lcov -- spec/Scrt.spec.ts.md"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
       '@hackbg/ubik': link:ensuite/toolbox/ubik
       '@types/dockerode': 3.3.14
       '@types/js-yaml': 4.0.5
-      '@types/node': 20.2.1
+      '@types/node': 20.3.0
       '@types/prettyjson': 0.0.30
       '@types/prompts': 2.4.4
       '@types/secure-random': 1.1.0
@@ -109,6 +109,19 @@ importers:
       '@fadroma/agent': link:../agent
       '@fadroma/scrt': link:scrt
       '@hackbg/conf': link:../ensuite/toolbox/conf
+
+  connect/cw:
+    specifiers:
+      '@hackbg/conf': ^2
+      '@hackbg/ensuite': ^1.0.2
+      '@types/ungap__structured-clone': ^0.3.0
+      '@ungap/structured-clone': ^1.0.1
+    dependencies:
+      '@hackbg/conf': 2.0.0
+      '@ungap/structured-clone': 1.0.1
+    devDependencies:
+      '@hackbg/ensuite': link:../../ensuite
+      '@types/ungap__structured-clone': 0.3.0
 
   connect/scrt:
     specifiers:
@@ -293,7 +306,7 @@ importers:
       signal-exit: 3.0.7
     devDependencies:
       '@hackbg/ubik': link:ubik
-      '@types/node': 20.2.1
+      '@types/node': 20.3.0
       concurrently: 7.2.2
       husky: 8.0.3
       lint-staged: 13.1.2
@@ -958,7 +971,7 @@ packages:
   /@types/docker-modem/3.0.2:
     resolution: {integrity: sha512-qC7prjoEYR2QEe6SmCVfB1x3rfcQtUr1n4x89+3e0wSTMQ/KYCyf+/RAA9n2tllkkNc6//JMUZePdFRiGIWfaQ==}
     dependencies:
-      '@types/node': 20.1.1
+      '@types/node': 20.3.0
       '@types/ssh2': 1.11.5
     dev: true
 
@@ -977,7 +990,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.0
-      '@types/node': 20.1.1
+      '@types/node': 20.3.0
     dev: true
 
   /@types/istanbul-lib-coverage/2.0.4:
@@ -1031,12 +1044,11 @@ packages:
     resolution: {integrity: sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==}
     dev: true
 
-  /@types/node/20.1.1:
-    resolution: {integrity: sha512-uKBEevTNb+l6/aCQaKVnUModfEMjAl98lw2Si9P5y4hLu9tm6AlX2ZIoXZX6Wh9lJueYPrGPKk5WMCNHg/u6/A==}
-    dev: true
-
   /@types/node/20.2.1:
     resolution: {integrity: sha512-DqJociPbZP1lbZ5SQPk4oag6W7AyaGMO6gSfRwq3PWl4PXTwJpRQJhDq4W0kzrg3w6tJ1SwlvGZ5uKFHY13LIg==}
+
+  /@types/node/20.3.0:
+    resolution: {integrity: sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ==}
 
   /@types/prettyjson/0.0.30:
     resolution: {integrity: sha512-BQ15wnnSvzlvDAVvd4t+zXjd9o6QAcfBeEUlZcinDYeb0A1xTfRBc0s8nxHlctojnsxDrbiG7amTqLWbXsiK7Q==}
@@ -1045,7 +1057,7 @@ packages:
   /@types/prompts/2.4.4:
     resolution: {integrity: sha512-p5N9uoTH76lLvSAaYSZtBCdEXzpOOufsRjnhjVSrZGXikVGHX9+cc9ERtHRV4hvBKHyZb1bg4K+56Bd2TqUn4A==}
     dependencies:
-      '@types/node': 20.2.1
+      '@types/node': 20.3.0
       kleur: 3.0.3
     dev: true
 
@@ -1064,7 +1076,7 @@ packages:
   /@types/ssh2/1.11.5:
     resolution: {integrity: sha512-RaBsPKr+YP/slH8iR7XfC7chyomU+V57F/gJ5cMSP2n6/YWKVmeRLx7lrkgw4YYLpEW5lXLAdfZJqGo0PXboSA==}
     dependencies:
-      '@types/node': 20.1.1
+      '@types/node': 20.3.0
     dev: true
 
   /@types/tmp/0.2.3:
@@ -3313,7 +3325,7 @@ packages:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/long': 4.0.2
-      '@types/node': 20.2.1
+      '@types/node': 20.3.0
       long: 4.0.0
     dev: false
 


### PR DESCRIPTION
This will allow Fadroma Agent and Fadroma Deploy to operate on CosmWasm chains other than Secret Network.

See also: #188 